### PR TITLE
[2201.3.x] Add resource method to API docs UI

### DIFF
--- a/docerina-ui/src/component/clients.js
+++ b/docerina-ui/src/component/clients.js
@@ -46,76 +46,76 @@ const Client = (props) => {
 
             <section className="construct-page">
                 {client != null &&
-                <section>
-                    <h1>Client: <span className={client.isDeprecated ? "strike clients" : "clients"}>{client.name}</span></h1>
-                    {
-                        client.isDeprecated == true &&
-                        <div className="ui orange horizontal label">Deprecated</div>
-                    }
-                    {
-                        client.isIsolated == true &&
-                        <div className="ui horizontal label">Isolated</div>
-                    }
-                    {
-                        client.isReadOnly == true &&
-                        <div className="ui horizontal label">Read Only</div>
-                    }
-                    <Markdown text={client.description} />
-                    <div className="constants">
-                        <div className="method-sum">
+                    <section>
+                        <h1>Client: <span className={client.isDeprecated ? "strike clients" : "clients"}>{client.name}</span></h1>
+                        {
+                            client.isDeprecated == true &&
+                            <div className="ui orange horizontal label">Deprecated</div>
+                        }
+                        {
+                            client.isIsolated == true &&
+                            <div className="ui horizontal label">Isolated</div>
+                        }
+                        {
+                            client.isReadOnly == true &&
+                            <div className="ui horizontal label">Read Only</div>
+                        }
+                        <Markdown text={client.description} />
+                        <div className="constants">
+                            <div className="method-sum">
 
-                            {client.initMethod != null && <InitMethod initMethod={client.initMethod} />}
+                                {client.initMethod != null && <InitMethod initMethod={client.initMethod} />}
 
-                            {client.remoteMethods != null && client.remoteMethods.length > 0 &&
-                            <section className="method-list">
-                                <h2>Remote Methods</h2>
-                                <div>
-                                    <MethodTable {...props} methods={client.remoteMethods} />
-                                </div>
-                            </section>
+                                {client.remoteMethods != null && client.remoteMethods.length > 0 &&
+                                    <section className="method-list">
+                                        <h2>Remote Methods</h2>
+                                        <div>
+                                            <MethodTable {...props} methods={client.remoteMethods} />
+                                        </div>
+                                    </section>
+                                }
+                                {client.resourceMethods != null && client.resourceMethods.length > 0 &&
+                                    <section className="method-list">
+                                        <h2>Resource Methods</h2>
+                                        <div>
+                                            <MethodTable {...props} methods={client.resourceMethods} />
+                                        </div>
+                                    </section>
+                                }
+                                {client.otherMethods != null && client.otherMethods.length > 0 &&
+                                    <section className="method-list">
+                                        <h2>Methods</h2>
+                                        <div className="method-list">
+                                            <MethodTable {...props} methods={client.otherMethods} />
+                                        </div>
+                                    </section>
+                                }
+                                {client.fields != null && client.fields.length > 0 &&
+                                    <section className="fields-list">
+                                        <h2>Fields</h2>
+                                        <div>
+                                            <Fields fields={client.fields} />
+                                        </div>
+                                    </section>
+                                }
+                            </div>
+                            {client.remoteMethods != null &&
+                                client.remoteMethods.map(item => (
+                                    <div key={item.name}><Method method={item} /></div>
+                                ))
                             }
-                            {client.resourceMethods != null && client.resourceMethods.length > 0 &&
-                            <section className="method-list">
-                                <h2>Resource Methods</h2>
-                                <div>
-                                    <MethodTable {...props} methods={client.resourceMethods} />
-                                </div>
-                            </section>
+                            {client.resourceMethods != null &&
+                                client.resourceMethods.map(item => (
+                                    <div key={item.name}><Method method={item} /></div>
+                                ))
                             }
-                            {client.otherMethods != null && client.otherMethods.length > 0 &&
-                            <section className="method-list">
-                                <h2>Methods</h2>
-                                <div className="method-list">
-                                    <MethodTable {...props} methods={client.otherMethods} />
-                                </div>
-                            </section>
-                            }
-                            {client.fields != null && client.fields.length > 0 &&
-                            <section className="fields-list">
-                                <h2>Fields</h2>
-                                <div>
-                                    <Fields fields={client.fields} />
-                                </div>
-                            </section>
+                            {client.otherMethods != null &&
+                                client.otherMethods.map(item => (
+                                    <div key={item.name}><Method method={item} /></div>
+                                ))
                             }
                         </div>
-                        {client.remoteMethods != null &&
-                        client.remoteMethods.map(item => (
-                            <div key={item.name}><Method method={item} /></div>
-                        ))
-                        }
-                        {client.resourceMethods != null &&
-                        client.resourceMethods.map(item => (
-                            <div key={item.name}><Method method={item} /></div>
-                        ))
-                        }
-                        {client.otherMethods != null &&
-                        client.otherMethods.map(item => (
-                            <div key={item.name}><Method method={item} /></div>
-                        ))
-                        }
-                    </div>
-                </section>
+                    </section>
                 }
             </section>
         </Layout>

--- a/docerina-ui/src/component/clients.js
+++ b/docerina-ui/src/component/clients.js
@@ -46,63 +46,76 @@ const Client = (props) => {
 
             <section className="construct-page">
                 {client != null &&
-                    <section>
-                        <h1>Client: <span className={client.isDeprecated ? "strike clients" : "clients"}>{client.name}</span></h1>
-                        {
-                            client.isDeprecated == true &&
-                            <div className="ui orange horizontal label">Deprecated</div>
-                        }
-                        {
-                            client.isIsolated == true &&
-                            <div className="ui horizontal label">Isolated</div>
-                        }
-                        {
-                            client.isReadOnly == true &&
-                            <div className="ui horizontal label">Read Only</div>
-                        }
-                        <Markdown text={client.description} />
-                        <div className="constants">
-                            <div className="method-sum">
+                <section>
+                    <h1>Client: <span className={client.isDeprecated ? "strike clients" : "clients"}>{client.name}</span></h1>
+                    {
+                        client.isDeprecated == true &&
+                        <div className="ui orange horizontal label">Deprecated</div>
+                    }
+                    {
+                        client.isIsolated == true &&
+                        <div className="ui horizontal label">Isolated</div>
+                    }
+                    {
+                        client.isReadOnly == true &&
+                        <div className="ui horizontal label">Read Only</div>
+                    }
+                    <Markdown text={client.description} />
+                    <div className="constants">
+                        <div className="method-sum">
 
-                                {client.initMethod != null && <InitMethod initMethod={client.initMethod} />}
+                            {client.initMethod != null && <InitMethod initMethod={client.initMethod} />}
 
-                                {client.remoteMethods != null && client.remoteMethods.length > 0 &&
-                                    <section className="method-list">
-                                        <h2>Remote Methods</h2>
-                                        <div>
-                                            <MethodTable {...props} methods={client.remoteMethods} />
-                                        </div>
-                                    </section>
-                                }
-                                {client.otherMethods != null && client.otherMethods.length > 0 &&
-                                    <section className="method-list">
-                                        <h2>Methods</h2>
-                                        <div className="method-list">
-                                            <MethodTable {...props} methods={client.otherMethods} />
-                                        </div>
-                                    </section>
-                                }
-                                {client.fields != null && client.fields.length > 0 &&
-                                    <section className="fields-list">
-                                        <h2>Fields</h2>
-                                        <div>
-                                            <Fields fields={client.fields} />
-                                        </div>
-                                    </section>
-                                }
-                            </div>
-                            {client.remoteMethods != null &&
-                                client.remoteMethods.map(item => (
-                                    <div key={item.name}><Method method={item} /></div>
-                                ))
+                            {client.remoteMethods != null && client.remoteMethods.length > 0 &&
+                            <section className="method-list">
+                                <h2>Remote Methods</h2>
+                                <div>
+                                    <MethodTable {...props} methods={client.remoteMethods} />
+                                </div>
+                            </section>
                             }
-                            {client.otherMethods != null &&
-                                client.otherMethods.map(item => (
-                                    <div key={item.name}><Method method={item} /></div>
-                                ))
+                            {client.resourceMethods != null && client.resourceMethods.length > 0 &&
+                            <section className="method-list">
+                                <h2>Resource Methods</h2>
+                                <div>
+                                    <MethodTable {...props} methods={client.resourceMethods} />
+                                </div>
+                            </section>
+                            }
+                            {client.otherMethods != null && client.otherMethods.length > 0 &&
+                            <section className="method-list">
+                                <h2>Methods</h2>
+                                <div className="method-list">
+                                    <MethodTable {...props} methods={client.otherMethods} />
+                                </div>
+                            </section>
+                            }
+                            {client.fields != null && client.fields.length > 0 &&
+                            <section className="fields-list">
+                                <h2>Fields</h2>
+                                <div>
+                                    <Fields fields={client.fields} />
+                                </div>
+                            </section>
                             }
                         </div>
-                    </section>
+                        {client.remoteMethods != null &&
+                        client.remoteMethods.map(item => (
+                            <div key={item.name}><Method method={item} /></div>
+                        ))
+                        }
+                        {client.resourceMethods != null &&
+                        client.resourceMethods.map(item => (
+                            <div key={item.name}><Method method={item} /></div>
+                        ))
+                        }
+                        {client.otherMethods != null &&
+                        client.otherMethods.map(item => (
+                            <div key={item.name}><Method method={item} /></div>
+                        ))
+                        }
+                    </div>
+                </section>
                 }
             </section>
         </Layout>

--- a/docerina-ui/src/component/method.js
+++ b/docerina-ui/src/component/method.js
@@ -24,15 +24,23 @@ import { Link } from '../Router'
 const Method = (props) => {
     return (
         <div className="method-content construct-page">
-            <div className="main-method-title" id={props.method.name} title={props.method.name}>
+            <div className="main-method-title" id={props.method.isResource ?
+                props.method.accessor + '-' + props.method.resourcePath.replace(/[^\w\s]/gi, '-')
+                : props.method.name} title={props.method.isResource ?
+                props.method.accessor + '-' + props.method.resourcePath.replace(/[^\w\s]/gi, '-')
+                : props.method.name}>
 
-                <h2 className={props.method.isDeprecated ? "strike" : ""}> {props.method.name} </h2>
+                <h2 className={props.method.isDeprecated ? "strike" : ""}> {props.method.isResource ?
+                    <><i>{props.method.accessor}</i> {props.method.resourcePath}</>
+                    : props.method.name} </h2>
             </div>
             <div>
                 <pre className="method-signature">
-                    <code className="break-spaces"><span className="token keyword">function</span> {props.method.name}(
-            {props.method.parameters.length > 0 && props.method.parameters.map(param => { return [getTypeLabel(param.type), " " + param.name]; }).reduce((prev, curr) => [prev, ', ', curr])})
-            {props.method.returnParameters.length > 0 && <span> <span className="token keyword">returns</span> {getTypeLabel(props.method.returnParameters[0].type)}</span>}
+                    <code className="break-spaces"><span className="token keyword">function</span> {props.method.isResource ?
+                        <><i>{props.method.accessor}</i> {props.method.resourcePath}</>
+                        : props.method.name}(
+                        {props.method.parameters.length > 0 && props.method.parameters.map(param => { return [getTypeLabel(param.type), " " + param.name]; }).reduce((prev, curr) => [prev, ', ', curr])})
+                        {props.method.returnParameters.length > 0 && <span> <span className="token keyword">returns</span> {getTypeLabel(props.method.returnParameters[0].type)}</span>}
                     </code>
                 </pre>
             </div>
@@ -49,41 +57,45 @@ const Method = (props) => {
                     props.method.isRemote == true &&
                     <div className="ui horizontal label">Remote Function</div>
                 }
+                {
+                    props.method.isResource == true &&
+                    <div className="ui horizontal label">Resource Function</div>
+                }
                 <Markdown text={props.method.description} />
                 {props.method.inclusionType != null && <p>Method included from <span data-tooltip="Type inclusion" data-position="top left">*</span>{getTypeLabel(props.method.inclusionType)}</p>}
             </div>
             {props.method.inclusionType == null &&
-                <>
-                    {props.method.parameters.length > 0 &&
-                        <div className="parameters">
-                            <h3 className="param-title">Parameters</h3>
-                            {props.method.parameters.map(item => (
-                                <div key={item.name} className="params-listing">
-                                    <ul>
-                                        <li>
-                                            <span className={item.isDeprecated ? "strike" : ""}>{item.name}</span>
-                                            <span className="type">  {getTypeLabel(item.type)} </span>
-                                            {item.defaultValue != "" && <span className="default"> (default {item.defaultValue})</span>}
-                                        </li>
-                                        {
-                                            item.isDeprecated == true &&
-                                            <div className="ui orange horizontal label">Deprecated</div>
-                                        }
-                                        <Markdown text={item.description} />
+            <>
+                {props.method.parameters.length > 0 &&
+                <div className="parameters">
+                    <h3 className="param-title">Parameters</h3>
+                    {props.method.parameters.map(item => (
+                        <div key={item.name} className="params-listing">
+                            <ul>
+                                <li>
+                                    <span className={item.isDeprecated ? "strike" : ""}>{item.name}</span>
+                                    <span className="type">  {getTypeLabel(item.type)} </span>
+                                    {item.defaultValue != "" && <span className="default"> (default {item.defaultValue})</span>}
+                                </li>
+                                {
+                                    item.isDeprecated == true &&
+                                    <div className="ui orange horizontal label">Deprecated</div>
+                                }
+                                <Markdown text={item.description} />
 
-                                    </ul>
-                                </div>
-                            ))}
+                            </ul>
                         </div>
-                    }
+                    ))}
+                </div>
+                }
 
-                    {props.method.returnParameters.length > 0 &&
-                        <div className="returns-listing">
-                            <h3 className="type">Return Type</h3> (<span className="type">{getTypeLabel(props.method.returnParameters[0].type)}</span>)
+                {props.method.returnParameters.length > 0 &&
+                <div className="returns-listing">
+                    <h3 className="type">Return Type</h3> (<span className="type">{getTypeLabel(props.method.returnParameters[0].type)}</span>)
                     <Markdown text={props.method.returnParameters[0].description} />
-                        </div>
-                    }
-                </>
+                </div>
+                }
+            </>
             }
         </div>
     );

--- a/docerina-ui/src/component/method.js
+++ b/docerina-ui/src/component/method.js
@@ -65,37 +65,37 @@ const Method = (props) => {
                 {props.method.inclusionType != null && <p>Method included from <span data-tooltip="Type inclusion" data-position="top left">*</span>{getTypeLabel(props.method.inclusionType)}</p>}
             </div>
             {props.method.inclusionType == null &&
-            <>
-                {props.method.parameters.length > 0 &&
-                <div className="parameters">
-                    <h3 className="param-title">Parameters</h3>
-                    {props.method.parameters.map(item => (
-                        <div key={item.name} className="params-listing">
-                            <ul>
-                                <li>
-                                    <span className={item.isDeprecated ? "strike" : ""}>{item.name}</span>
-                                    <span className="type">  {getTypeLabel(item.type)} </span>
-                                    {item.defaultValue != "" && <span className="default"> (default {item.defaultValue})</span>}
-                                </li>
-                                {
-                                    item.isDeprecated == true &&
-                                    <div className="ui orange horizontal label">Deprecated</div>
-                                }
-                                <Markdown text={item.description} />
+                <>
+                    {props.method.parameters.length > 0 &&
+                        <div className="parameters">
+                            <h3 className="param-title">Parameters</h3>
+                            {props.method.parameters.map(item => (
+                                <div key={item.name} className="params-listing">
+                                    <ul>
+                                        <li>
+                                            <span className={item.isDeprecated ? "strike" : ""}>{item.name}</span>
+                                            <span className="type">  {getTypeLabel(item.type)} </span>
+                                            {item.defaultValue != "" && <span className="default"> (default {item.defaultValue})</span>}
+                                        </li>
+                                        {
+                                            item.isDeprecated == true &&
+                                            <div className="ui orange horizontal label">Deprecated</div>
+                                        }
+                                        <Markdown text={item.description} />
 
-                            </ul>
+                                    </ul>
+                                </div>
+                            ))}
                         </div>
-                    ))}
-                </div>
-                }
+                    }
 
-                {props.method.returnParameters.length > 0 &&
-                <div className="returns-listing">
-                    <h3 className="type">Return Type</h3> (<span className="type">{getTypeLabel(props.method.returnParameters[0].type)}</span>)
-                    <Markdown text={props.method.returnParameters[0].description} />
-                </div>
-                }
-            </>
+                    {props.method.returnParameters.length > 0 &&
+                        <div className="returns-listing">
+                            <h3 className="type">Return Type</h3> (<span className="type">{getTypeLabel(props.method.returnParameters[0].type)}</span>)
+                            <Markdown text={props.method.returnParameters[0].description} />
+                        </div>
+                    }
+                </>
             }
         </div>
     );

--- a/docerina-ui/src/component/methodTable.js
+++ b/docerina-ui/src/component/methodTable.js
@@ -27,29 +27,29 @@ const MethodTable = (props) => {
         <section>
             <table className="ui very basic table">
                 <tbody>
-                {props.methods.map(item => (
-                    <tr key={item.isResource ?
-                        item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
-                        : item.name}>
-                        <td className={item.isDeprecated ? "module-title strike" : "module-title"} title={item.isResource ?
+                    {props.methods.map(item => (
+                        <tr key={item.isResource ?
                             item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
                             : item.name}>
-                            <Link to={`/${props.module.orgName}/${props.module.id}/${props.module.version}/${props.pageType}/${props.match.params.constructName}#${item.isResource ?
+                            <td className={item.isDeprecated ? "module-title strike" : "module-title"} title={item.isResource ?
                                 item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
-                                : item.name}`}>{item.isResource ?
-                                <><i>{item.accessor}</i> {item.resourcePath}</>
-                                : item.name}</Link>
-                        </td>
-                        <td className="module-desc">
-                            {
-                                item.isDeprecated == true &&
-                                <div className="ui orange horizontal label" data-tooltip="Deprecated" data-position="top left">D</div>
-                            }
-                            {item.inclusionType == null && <Markdown text={getFirstLine(item.description)} />}
-                            {item.inclusionType != null && <p>Method included from {getTypeLabel(item.inclusionType)}</p>}
-                        </td>
-                    </tr>
-                ))}
+                                : item.name}>
+                                <Link to={`/${props.module.orgName}/${props.module.id}/${props.module.version}/${props.pageType}/${props.match.params.constructName}#${item.isResource ?
+                                    item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
+                                    : item.name}`}>{item.isResource ?
+                                    <><i>{item.accessor}</i> {item.resourcePath}</>
+                                    : item.name}</Link>
+                            </td>
+                            <td className="module-desc">
+                                {
+                                    item.isDeprecated == true &&
+                                    <div className="ui orange horizontal label" data-tooltip="Deprecated" data-position="top left">D</div>
+                                }
+                                {item.inclusionType == null && <Markdown text={getFirstLine(item.description)} />}
+                                {item.inclusionType != null && <p>Method included from {getTypeLabel(item.inclusionType)}</p>}
+                            </td>
+                        </tr>
+                    ))}
                 </tbody>
             </table>
         </section>

--- a/docerina-ui/src/component/methodTable.js
+++ b/docerina-ui/src/component/methodTable.js
@@ -27,21 +27,29 @@ const MethodTable = (props) => {
         <section>
             <table className="ui very basic table">
                 <tbody>
-                    {props.methods.map(item => (
-                        <tr key={item.name}>
-                            <td className={item.isDeprecated ? "module-title strike" : "module-title"} title={item.name}>
-                                <Link to={`/${props.module.orgName}/${props.module.id}/${props.module.version}/${props.pageType}/${props.match.params.constructName}#${item.name}`}>{item.name}</Link>
-                            </td>
-                            <td className="module-desc">
-                                {
-                                    item.isDeprecated == true &&
-                                    <div className="ui orange horizontal label" data-tooltip="Deprecated" data-position="top left">D</div>
-                                }
-                                {item.inclusionType == null && <Markdown text={getFirstLine(item.description)} />}
-                                {item.inclusionType != null && <p>Method included from {getTypeLabel(item.inclusionType)}</p>}
-                            </td>
-                        </tr>
-                    ))}
+                {props.methods.map(item => (
+                    <tr key={item.isResource ?
+                        item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
+                        : item.name}>
+                        <td className={item.isDeprecated ? "module-title strike" : "module-title"} title={item.isResource ?
+                            item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
+                            : item.name}>
+                            <Link to={`/${props.module.orgName}/${props.module.id}/${props.module.version}/${props.pageType}/${props.match.params.constructName}#${item.isResource ?
+                                item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
+                                : item.name}`}>{item.isResource ?
+                                <><i>{item.accessor}</i> {item.resourcePath}</>
+                                : item.name}</Link>
+                        </td>
+                        <td className="module-desc">
+                            {
+                                item.isDeprecated == true &&
+                                <div className="ui orange horizontal label" data-tooltip="Deprecated" data-position="top left">D</div>
+                            }
+                            {item.inclusionType == null && <Markdown text={getFirstLine(item.description)} />}
+                            {item.inclusionType != null && <p>Method included from {getTypeLabel(item.inclusionType)}</p>}
+                        </td>
+                    </tr>
+                ))}
                 </tbody>
             </table>
         </section>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=0.10.8-SNAPSHOT
+version=0.10.9-SNAPSHOT
 ballerinaLangVersion=2201.4.0-20221212-011800-9715f15d
 
 ballerinaGradlePluginVersion=0.15.0


### PR DESCRIPTION
## Purpose
Changes have been made from ballerina-lang side to add resource kind in api-docs.json file when we are using `bal doc` command.
This will add the UI for resource methods in API docs generated from `bal doc` command.

### Fixes #175 

## Samples
<img width="1420" alt="Screenshot 2023-03-02 at 12 42 57" src="https://user-images.githubusercontent.com/51471998/222357092-9953d467-6d97-43a7-a8b1-c6dd0db6b7e0.png">

<img width="1422" alt="Screenshot 2023-03-02 at 12 13 53" src="https://user-images.githubusercontent.com/51471998/222356712-27cfa5c6-0fb8-4501-86ea-e7fea6125a7b.png">

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/39695
https://github.com/ballerina-platform/ballerina-dev-tools/pull/176