### PR TITLE
[2201.4.x] Add resource method to API docs UI

### DIFF
--- a/docerina-ui/src/component/clients.js
+++ b/docerina-ui/src/component/clients.js
@@ -74,6 +74,14 @@ const Client = (props) => {
                                         </div>
                                     </section>
                                 }
+                                {client.resourceMethods != null && client.resourceMethods.length > 0 &&
+                                <section className="method-list">
+                                    <h2>Resource Methods</h2>
+                                    <div>
+                                        <MethodTable {...props} methods={client.resourceMethods} />
+                                    </div>
+                                </section>
+                                }
                                 {client.otherMethods != null && client.otherMethods.length > 0 &&
                                     <section className="method-list">
                                         <h2>Methods</h2>
@@ -95,6 +103,11 @@ const Client = (props) => {
                                 client.remoteMethods.map(item => (
                                     <div key={item.name}><Method method={item} /></div>
                                 ))
+                            }
+                            {client.resourceMethods != null &&
+                            client.resourceMethods.map(item => (
+                                <div key={item.name}><Method method={item} /></div>
+                            ))
                             }
                             {client.otherMethods != null &&
                                 client.otherMethods.map(item => (

--- a/docerina-ui/src/component/method.js
+++ b/docerina-ui/src/component/method.js
@@ -24,13 +24,21 @@ import { Link } from '../Router'
 const Method = (props) => {
     return (
         <div className="method-content construct-page">
-            <div className="main-method-title" id={props.method.name} title={props.method.name}>
+            <div className="main-method-title" id={props.method.isResource ?
+                props.method.accessor + '-' + props.method.resourcePath.replace(/[^\w\s]/gi, '-')
+                : props.method.name} title={props.method.isResource ?
+                props.method.accessor + '-' + props.method.resourcePath.replace(/[^\w\s]/gi, '-')
+                : props.method.name}>
 
-                <h2 className={props.method.isDeprecated ? "strike" : ""}> {props.method.name} </h2>
+                <h2 className={props.method.isDeprecated ? "strike" : ""}> {props.method.isResource ?
+                    <><i>{props.method.accessor}</i> {props.method.resourcePath}</>
+                    : props.method.name} </h2>
             </div>
             <div>
                 <pre className="method-signature">
-                    <code className="break-spaces"><span className="token keyword">function</span> {props.method.name}(
+                    <code className="break-spaces"><span className="token keyword">function</span> {props.method.isResource ?
+                        <><i>{props.method.accessor}</i> {props.method.resourcePath}</>
+                        : props.method.name}(
             {props.method.parameters.length > 0 && props.method.parameters.map(param => { return [getTypeLabel(param.type), " " + param.name]; }).reduce((prev, curr) => [prev, ', ', curr])})
             {props.method.returnParameters.length > 0 && <span> <span className="token keyword">returns</span> {getTypeLabel(props.method.returnParameters[0].type)}</span>}
                     </code>
@@ -48,6 +56,10 @@ const Method = (props) => {
                 {
                     props.method.isRemote == true &&
                     <div className="ui horizontal label">Remote Function</div>
+                }
+                {
+                    props.method.isResource == true &&
+                    <div className="ui horizontal label">Resource Function</div>
                 }
                 <Markdown text={props.method.description} />
                 {props.method.inclusionType != null && <p>Method included from <span data-tooltip="Type inclusion" data-position="top left">*</span>{getTypeLabel(props.method.inclusionType)}</p>}

--- a/docerina-ui/src/component/methodTable.js
+++ b/docerina-ui/src/component/methodTable.js
@@ -28,9 +28,17 @@ const MethodTable = (props) => {
             <table className="ui very basic table">
                 <tbody>
                     {props.methods.map(item => (
-                        <tr key={item.name}>
-                            <td className={item.isDeprecated ? "module-title strike" : "module-title"} title={item.name}>
-                                <Link to={`/${props.module.orgName}/${props.module.id}/${props.module.version}/${props.pageType}/${props.match.params.constructName}#${item.name}`}>{item.name}</Link>
+                        <tr key={item.isResource ?
+                            item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
+                            : item.name}>
+                            <td className={item.isDeprecated ? "module-title strike" : "module-title"} title={item.isResource ?
+                                item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
+                                : item.name}>
+                                <Link to={`/${props.module.orgName}/${props.module.id}/${props.module.version}/${props.pageType}/${props.match.params.constructName}#${item.isResource ?
+                                    item.accessor + '-' + item.resourcePath.replace(/[^\w\s]/gi, '-')
+                                    : item.name}`}>{item.isResource ?
+                                    <><i>{item.accessor}</i> {item.resourcePath}</>
+                                    : item.name}</Link>
                             </td>
                             <td className="module-desc">
                                 {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=0.10.8-SNAPSHOT
+version=0.11.0-SNAPSHOT
 ballerinaLangVersion=2201.4.0
 
 ballerinaGradlePluginVersion=0.15.0


### PR DESCRIPTION
## Purpose
Changes have been made from ballerina-lang side to add resource kind in api-docs.json file when we are using `bal doc` command.
This will add the UI for resource methods in API docs generated from `bal doc` command.

### Fixes #175 

## Samples
<img width="1420" alt="Screenshot 2023-03-02 at 12 42 57" src="https://user-images.githubusercontent.com/51471998/222357092-9953d467-6d97-43a7-a8b1-c6dd0db6b7e0.png">

<img width="1422" alt="Screenshot 2023-03-02 at 12 13 53" src="https://user-images.githubusercontent.com/51471998/222356712-27cfa5c6-0fb8-4501-86ea-e7fea6125a7b.png">

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/39695
https://github.com/ballerina-platform/ballerina-dev-tools/pull/177