### PR TITLE
Add categories to the `getAvailableNodes` API

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
@@ -19,8 +19,11 @@
 package io.ballerina.flowmodelgenerator.core;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import io.ballerina.flowmodelgenerator.core.model.Category;
 import io.ballerina.flowmodelgenerator.core.model.FlowNode;
+import io.ballerina.flowmodelgenerator.core.model.Item;
 
 import java.util.List;
 
@@ -31,17 +34,42 @@ import java.util.List;
  */
 public class AvailableNodesGenerator {
 
+    private final Category.Builder rootBuilder;
+
+    public AvailableNodesGenerator() {
+        this.rootBuilder = new Category.Builder(Category.Name.ROOT, null);
+        initializeCommonNodes();
+    }
+
     public JsonArray getAvailableNodes() {
         Gson gson = new Gson();
-        return gson.toJsonTree(
-                List.of(
-                        FlowNode.Kind.IF,
-                        FlowNode.Kind.HTTP_API_GET_CALL,
-                        FlowNode.Kind.HTTP_API_POST_CALL,
-                        FlowNode.Kind.RETURN,
-                        FlowNode.Kind.EXPRESSION,
-                        FlowNode.Kind.WHILE,
-                        FlowNode.Kind.ERROR_HANDLER
-                )).getAsJsonArray();
+        Category rootCategory = this.rootBuilder.build();
+        return gson.toJsonTree(rootCategory.items()).getAsJsonArray();
+    }
+
+    private void initializeCommonNodes() {
+        // Initialize the builder with the common nodes
+        this.rootBuilder
+                .stepIn(Category.Name.FLOW)
+                    .stepIn(Category.Name.BRANCH)
+                        .node(FlowNode.Kind.IF)
+                        .stepOut()
+                    .stepIn(Category.Name.ITERATION)
+                        .node(FlowNode.Kind.WHILE)
+                        .node(FlowNode.Kind.BREAK)
+                        .node(FlowNode.Kind.CONTINUE)
+                        .stepOut()
+                    .stepIn(Category.Name.CONTROL)
+                        .node(FlowNode.Kind.RETURN)
+                        .stepOut()
+                    .stepOut()
+                .stepIn(Category.Name.DATA)
+                    .stepOut()
+                .stepIn(Category.Name.ACTION)
+                    .stepIn(Category.Name.HTTP_API)
+                        .node(FlowNode.Kind.HTTP_API_GET_CALL)
+                        .node(FlowNode.Kind.HTTP_API_POST_CALL)
+                        .stepOut()
+                    .stepOut();
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
@@ -19,13 +19,9 @@
 package io.ballerina.flowmodelgenerator.core;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import io.ballerina.flowmodelgenerator.core.model.Category;
 import io.ballerina.flowmodelgenerator.core.model.FlowNode;
-import io.ballerina.flowmodelgenerator.core.model.Item;
-
-import java.util.List;
 
 /**
  * Generates available nodes for a given position in the diagram.

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/NodeTemplateGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/NodeTemplateGenerator.java
@@ -4,19 +4,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import io.ballerina.flowmodelgenerator.core.model.FlowNode;
-import io.ballerina.flowmodelgenerator.core.model.node.Break;
-import io.ballerina.flowmodelgenerator.core.model.node.Continue;
-import io.ballerina.flowmodelgenerator.core.model.node.DefaultExpression;
-import io.ballerina.flowmodelgenerator.core.model.node.ErrorHandler;
-import io.ballerina.flowmodelgenerator.core.model.node.If;
-import io.ballerina.flowmodelgenerator.core.model.node.Panic;
-import io.ballerina.flowmodelgenerator.core.model.node.Return;
-import io.ballerina.flowmodelgenerator.core.model.node.Start;
-import io.ballerina.flowmodelgenerator.core.model.node.While;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * Generates the node template for the given node kind.
@@ -29,18 +19,6 @@ public class NodeTemplateGenerator {
 
     private static final Map<FlowNode.Kind, FlowNode> nodeCache = new HashMap<>();
 
-    private static final Map<FlowNode.Kind, Supplier<? extends FlowNode>> constructorMap = Map.of(
-            FlowNode.Kind.IF, If::new,
-            FlowNode.Kind.RETURN, Return::new,
-            FlowNode.Kind.EXPRESSION, DefaultExpression::new,
-            FlowNode.Kind.ERROR_HANDLER, ErrorHandler::new,
-            FlowNode.Kind.WHILE, While::new,
-            FlowNode.Kind.CONTINUE, Continue::new,
-            FlowNode.Kind.BREAK, Break::new,
-            FlowNode.Kind.PANIC, Panic::new,
-            FlowNode.Kind.START, Start::new
-    );
-
     public JsonElement getNodeTemplate(String kindStr) {
         FlowNode.Kind kind = FlowNode.Kind.valueOf(kindStr);
         FlowNode flowNode = nodeCache.get(kind);
@@ -48,7 +26,7 @@ public class NodeTemplateGenerator {
             return gson.toJsonTree(flowNode);
         }
 
-        flowNode = constructorMap.getOrDefault(kind, DefaultExpression::new).get();
+        flowNode = FlowNode.getNodeFromKind(kind);
         flowNode.setConstData();
         flowNode.setTemplateData();
         nodeCache.put(flowNode.kind(), flowNode);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/AvailableNode.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/AvailableNode.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.model;
+
+import java.util.List;
+
+/**
+ * Represents a node that is available to the given cursor position.
+ *
+ * @param id          the id of the node
+ * @param name        the name of the node
+ * @param description the description of the node
+ * @param keywords    the keywords of the node
+ * @param enabled     whether the node is enabled
+ * @since 1.4.0
+ */
+public record AvailableNode(String id, String name, String description, List<String> keywords, boolean enabled)
+        implements Item {
+
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Category.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Category.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.model;
+
+import io.ballerina.flowmodelgenerator.core.model.node.ActionCall;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a category of the available nodes.
+ *
+ * @param name        name of the category
+ * @param description description of the category
+ * @param keywords    keywords of the category
+ * @param items       items in the category
+ * @since 1.4.0
+ */
+public record Category(String name, String description, List<String> keywords, List<Item> items) implements Item {
+
+    /**
+     * Represents the name of a category which contains the metadata of the category.
+     *
+     * @since 1.4.0
+     */
+    public enum Name {
+        ROOT("Root", "The topmost category of the palette", null),
+        FLOW("Flow", "Flow control nodes", List.of("Core", "Control", "Flow")),
+        BRANCH("Branch", "Branching nodes", null),
+        ITERATION("Iteration", "Iteration nodes", null),
+        CONTROL("Control", "Control nodes", null),
+        CONCURRENCY("Concurrency", "Concurrency nodes", null),
+        DATA("Data", "Data nodes are used to create, read, update, delete, and transform data", null),
+        ACTION("Action", "Connect to different services, APIs, SaaS products, etc.", null),
+        HTTP_API("HTTP API", "Make HTTP requests", null);
+
+        final String name;
+        final String description;
+        final List<String> keywords;
+
+        Name(String name, String description, List<String> keywords) {
+            this.name = name;
+            this.description = description;
+            this.keywords = keywords;
+        }
+    }
+
+    /**
+     * Represents a builder for the category. The builder can build the categories in a nested manner.
+     *
+     * @since 1.4.0
+     */
+    public static class Builder {
+
+        private final Name name;
+        private final Builder parentBuilder;
+        private final Map<Name, Builder> childBuilders;
+        private final List<AvailableNode> availableNodes;
+
+        public Builder(Name name, Builder parentBuilder) {
+            this.name = name;
+            this.parentBuilder = parentBuilder;
+            this.childBuilders = new LinkedHashMap<>();
+            this.availableNodes = new ArrayList<>();
+        }
+
+        public Builder stepIn(Name childName) {
+            Builder builder = this.childBuilders.get(childName);
+            if (builder == null) {
+                builder = new Builder(childName, this);
+                this.childBuilders.put(childName, builder);
+            }
+            return builder;
+        }
+
+        public Builder stepOut() {
+            if (parentBuilder == null) {
+                throw new IllegalStateException("Cannot step out of the root category");
+            }
+            return parentBuilder;
+        }
+
+        public Builder node(FlowNode.Kind kind) {
+            FlowNode flowNode = FlowNode.getNodeFromKind(kind);
+            if (flowNode instanceof ActionCall) {
+                NodeAttributes.Info info = NodeAttributes.get(kind);
+                flowNode.kind = kind;
+                flowNode.label = info.label();
+            }
+            AvailableNode availableNode = flowNode.extractAvailableNode();
+            this.availableNodes.add(availableNode);
+            return this;
+        }
+
+        public Category build() {
+            // Check for illegal state where both nodes and categories are present
+            if (!this.availableNodes.isEmpty() && !this.childBuilders.isEmpty()) {
+                throw new IllegalStateException("A category cannot have both categories and nodes as items");
+            }
+
+            List<Item> items = new ArrayList<>();
+
+            // If nodes are present, build them into items
+            if (!this.availableNodes.isEmpty()) {
+                items.addAll(this.availableNodes);
+            } else {
+                // If categories are present, build each category and add as items
+                this.childBuilders.forEach((key, value) -> items.add(value.build()));
+            }
+
+            // Create and return the new category with the built items
+            return new Category(name.name, name.description, name.keywords, items);
+        }
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FlowNode.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FlowNode.java
@@ -90,17 +90,18 @@ public abstract class FlowNode {
     protected int flags;
 
     private static final Map<FlowNode.Kind, Supplier<? extends FlowNode>> CONSTRUCTOR_MAP = new HashMap<>() {{
-        put(FlowNode.Kind.IF, If::new);
-        put(FlowNode.Kind.RETURN, Return::new);
-        put(FlowNode.Kind.EXPRESSION, DefaultExpression::new);
-        put(FlowNode.Kind.ERROR_HANDLER, ErrorHandler::new);
-        put(FlowNode.Kind.WHILE, While::new);
-        put(FlowNode.Kind.CONTINUE, Continue::new);
-        put(FlowNode.Kind.BREAK, Break::new);
-        put(FlowNode.Kind.PANIC, Panic::new);
-        put(FlowNode.Kind.EVENT_HTTP_API, HttpApiEvent::new);
-        put(FlowNode.Kind.HTTP_API_GET_CALL, ActionCall::new);
-        put(FlowNode.Kind.HTTP_API_POST_CALL, ActionCall::new);
+        put(Kind.IF, If::new);
+        put(Kind.RETURN, Return::new);
+        put(Kind.EXPRESSION, DefaultExpression::new);
+        put(Kind.ERROR_HANDLER, ErrorHandler::new);
+        put(Kind.WHILE, While::new);
+        put(Kind.CONTINUE, Continue::new);
+        put(Kind.BREAK, Break::new);
+        put(Kind.PANIC, Panic::new);
+        put(Kind.EVENT_HTTP_API, HttpApiEvent::new);
+        put(Kind.HTTP_API_GET_CALL, ActionCall::new);
+        put(Kind.HTTP_API_POST_CALL, ActionCall::new);
+        put(Kind.START, Start::new);
     }};
 
     public static FlowNode getNodeFromKind(Kind kind) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FlowNode.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FlowNode.java
@@ -89,6 +89,24 @@ public abstract class FlowNode {
     protected Map<String, Expression> nodeProperties;
     protected int flags;
 
+    private static final Map<FlowNode.Kind, Supplier<? extends FlowNode>> CONSTRUCTOR_MAP = new HashMap<>() {{
+        put(FlowNode.Kind.IF, If::new);
+        put(FlowNode.Kind.RETURN, Return::new);
+        put(FlowNode.Kind.EXPRESSION, DefaultExpression::new);
+        put(FlowNode.Kind.ERROR_HANDLER, ErrorHandler::new);
+        put(FlowNode.Kind.WHILE, While::new);
+        put(FlowNode.Kind.CONTINUE, Continue::new);
+        put(FlowNode.Kind.BREAK, Break::new);
+        put(FlowNode.Kind.PANIC, Panic::new);
+        put(FlowNode.Kind.EVENT_HTTP_API, HttpApiEvent::new);
+        put(FlowNode.Kind.HTTP_API_GET_CALL, ActionCall::new);
+        put(FlowNode.Kind.HTTP_API_POST_CALL, ActionCall::new);
+    }};
+
+    public static FlowNode getNodeFromKind(Kind kind) {
+        return CONSTRUCTOR_MAP.getOrDefault(kind, DefaultExpression::new).get();
+    }
+
     protected FlowNode() {
     }
 
@@ -118,6 +136,11 @@ public abstract class FlowNode {
 
     public boolean returning() {
         return returning;
+    }
+
+    public AvailableNode extractAvailableNode() {
+        this.setConstData();
+        return new AvailableNode(kind.name(), label, description, null, true);
     }
 
     public abstract void setConstData();

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Item.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Item.java
@@ -19,7 +19,7 @@
 package io.ballerina.flowmodelgenerator.core.model;
 
 /**
- * Represents an item for an available node
+ * Represents an item in the available nodes.
  *
  * @since 1.4.0
  */

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Item.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Item.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.model;
+
+/**
+ * Represents an item for an available node
+ *
+ * @since 1.4.0
+ */
+public interface Item {
+
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/AvailableNodesTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/AvailableNodesTest.java
@@ -19,17 +19,14 @@
 package io.ballerina.flowmodelgenerator.extension;
 
 import com.google.gson.JsonArray;
-import com.google.gson.reflect.TypeToken;
 import io.ballerina.flowmodelgenerator.extension.request.FlowModelAvailableNodesRequest;
 import io.ballerina.tools.text.LineRange;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 /**
  * Test for the getting available nodes service.
@@ -37,9 +34,6 @@ import java.util.List;
  * @since 1.4.0
  */
 public class AvailableNodesTest extends AbstractLSTest {
-
-    private static final Type availableNodesType = new TypeToken<List<String>>() {
-    }.getType();
 
     @Override
     @Test(dataProvider = "data-provider")
@@ -51,10 +45,10 @@ public class AvailableNodesTest extends AbstractLSTest {
                 testConfig.parentNodeKind(), testConfig.branchLabel());
         JsonArray availableNodes = getResponse(request).getAsJsonArray("availableNodes");
 
-        List<String> actualAvailableNodes = gson.fromJson(availableNodes, availableNodesType);
-        if (!assertArray("available nodes", actualAvailableNodes, testConfig.availableNodes())) {
+        JsonArray categories = availableNodes.getAsJsonArray();
+        if (!categories.equals(testConfig.categories())) {
             TestConfig updateConfig = new TestConfig(testConfig.description(), testConfig.parentNodeLineRange(),
-                    testConfig.parentNodeKind(), testConfig.branchLabel(), actualAvailableNodes);
+                    testConfig.parentNodeKind(), testConfig.branchLabel(), categories);
 //            updateConfig(config, updateConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }
@@ -83,10 +77,10 @@ public class AvailableNodesTest extends AbstractLSTest {
      * @param parentNodeLineRange The line range of the parent node
      * @param parentNodeKind      The kind of the parent node
      * @param branchLabel         The branch label
-     * @param availableNodes      The available nodes for the given input
+     * @param categories          The available categories for the given input
      */
     private record TestConfig(String description, LineRange parentNodeLineRange, String parentNodeKind,
-                              String branchLabel, List<String> availableNodes) {
+                              String branchLabel, JsonArray categories) {
 
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/simple.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/available_nodes/simple.json
@@ -2,13 +2,92 @@
   "description": "A simple example of a package",
   "parentNodeKind": "IF",
   "branchLabel": "THEN",
-  "availableNodes": [
-    "IF",
-    "HTTP_API_GET_CALL",
-    "HTTP_API_POST_CALL",
-    "RETURN",
-    "EXPRESSION",
-    "WHILE",
-    "ERROR_HANDLER"
+  "categories": [
+    {
+      "name": "Flow",
+      "description": "Flow control nodes",
+      "keywords": [
+        "Core",
+        "Control",
+        "Flow"
+      ],
+      "items": [
+        {
+          "name": "Branch",
+          "description": "Branching nodes",
+          "items": [
+            {
+              "id": "IF",
+              "name": "If",
+              "description": "Add conditional branch to the integration flow.",
+              "enabled": true
+            }
+          ]
+        },
+        {
+          "name": "Iteration",
+          "description": "Iteration nodes",
+          "items": [
+            {
+              "id": "WHILE",
+              "name": "While",
+              "description": "Loop over a block of code.",
+              "enabled": true
+            },
+            {
+              "id": "BREAK",
+              "name": "Break",
+              "description": "Exit the current loop",
+              "enabled": true
+            },
+            {
+              "id": "CONTINUE",
+              "name": "Continue",
+              "description": "Skip the current iteration and continue with the next one",
+              "enabled": true
+            }
+          ]
+        },
+        {
+          "name": "Control",
+          "description": "Control nodes",
+          "items": [
+            {
+              "id": "RETURN",
+              "name": "Return",
+              "description": "Return a value",
+              "enabled": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Data",
+      "description": "Data nodes are used to create, read, update, delete, and transform data",
+      "items": []
+    },
+    {
+      "name": "Action",
+      "description": "Connect to different services, APIs, SaaS products, etc.",
+      "items": [
+        {
+          "name": "HTTP API",
+          "description": "Make HTTP requests",
+          "items": [
+            {
+              "id": "HTTP_API_GET_CALL",
+              "name": "HTTP GET",
+              "enabled": true
+            },
+            {
+              "id": "HTTP_API_POST_CALL",
+              "name": "HTTP POST",
+              "enabled": true
+            }
+          ]
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
The PR introduces categories to the `getAvailableNode` API, using a builder pattern to provide available nodes based on cursor position.

1. Initially, a root category is created with common available nodes applicable at any instance. This is generated once during the construction of the object.
2. Depending on the context, the builder can traverse nested categories and add the corresponding node to the relevant category.