### PR TITLE
Adjust the line range of the start node

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -157,8 +157,10 @@ class CodeAnalyzer extends NodeVisitor {
             return;
         }
 
-        startNode(NodeKind.EVENT_START);
-        endNode(functionDefinitionNode);
+        startNode(NodeKind.EVENT_START).codedata()
+                .lineRange(functionDefinitionNode.functionBody().lineRange())
+                .sourceCode(functionDefinitionNode.toSourceCode().strip());
+        endNode();
         super.visit(functionDefinitionNode);
     }
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get1.json
@@ -9,12 +9,11 @@
   },
   "source": "http_get_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_get_node.bal",
     "nodes": [
       {
-        "id": "45234",
+        "id": "47001",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_get_node.bal",
             "startLine": {
               "line": 13,
-              "offset": 4
+              "offset": 61
             },
             "endLine": {
               "line": 28,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get2.json
@@ -9,12 +9,11 @@
   },
   "source": "http_get_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_get_node.bal",
     "nodes": [
       {
-        "id": "61726",
+        "id": "62656",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_get_node.bal",
             "startLine": {
               "line": 30,
-              "offset": 4
+              "offset": 34
             },
             "endLine": {
               "line": 33,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get3.json
@@ -9,12 +9,11 @@
   },
   "source": "http_get_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_get_node.bal",
     "nodes": [
       {
-        "id": "66655",
+        "id": "68577",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_get_node.bal",
             "startLine": {
               "line": 35,
-              "offset": 4
+              "offset": 66
             },
             "endLine": {
               "line": 37,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get4.json
@@ -13,7 +13,7 @@
     "fileName": "http_get_node.bal",
     "nodes": [
       {
-        "id": "70654",
+        "id": "72638",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "http_get_node.bal",
             "startLine": {
               "line": 39,
-              "offset": 4
+              "offset": 68
             },
             "endLine": {
               "line": 42,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post1.json
@@ -9,12 +9,11 @@
   },
   "source": "http_post_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_post_node.bal",
     "nodes": [
       {
-        "id": "45172",
+        "id": "46970",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_post_node.bal",
             "startLine": {
               "line": 13,
-              "offset": 4
+              "offset": 62
             },
             "endLine": {
               "line": 26,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post2.json
@@ -9,12 +9,11 @@
   },
   "source": "http_post_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_post_node.bal",
     "nodes": [
       {
-        "id": "59742",
+        "id": "60703",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_post_node.bal",
             "startLine": {
               "line": 28,
-              "offset": 4
+              "offset": 35
             },
             "endLine": {
               "line": 31,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post3.json
@@ -9,12 +9,11 @@
   },
   "source": "http_post_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_post_node.bal",
     "nodes": [
       {
-        "id": "64671",
+        "id": "66624",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_post_node.bal",
             "startLine": {
               "line": 33,
-              "offset": 4
+              "offset": 67
             },
             "endLine": {
               "line": 35,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post4.json
@@ -13,7 +13,7 @@
     "fileName": "http_post_node.bal",
     "nodes": [
       {
-        "id": "68670",
+        "id": "70685",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "http_post_node.bal",
             "startLine": {
               "line": 37,
-              "offset": 4
+              "offset": 69
             },
             "endLine": {
               "line": 40,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign1.json
@@ -9,12 +9,11 @@
   },
   "source": "update_data.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "update_data.bal",
     "nodes": [
       {
-        "id": "31869",
+        "id": "32582",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "update_data.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 23
             },
             "endLine": {
               "line": 4,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign2.json
@@ -9,12 +9,11 @@
   },
   "source": "update_data.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "update_data.bal",
     "nodes": [
       {
-        "id": "37790",
+        "id": "38689",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "update_data.bal",
             "startLine": {
               "line": 6,
-              "offset": 0
+              "offset": 29
             },
             "endLine": {
               "line": 9,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign3.json
@@ -13,7 +13,7 @@
     "fileName": "update_data.bal",
     "nodes": [
       {
-        "id": "42750",
+        "id": "43587",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "update_data.bal",
             "startLine": {
               "line": 11,
-              "offset": 0
+              "offset": 27
             },
             "endLine": {
               "line": 14,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign4.json
@@ -13,7 +13,7 @@
     "fileName": "update_data.bal",
     "nodes": [
       {
-        "id": "47710",
+        "id": "48516",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "update_data.bal",
             "startLine": {
               "line": 16,
-              "offset": 0
+              "offset": 26
             },
             "endLine": {
               "line": 19,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign5.json
@@ -13,7 +13,7 @@
     "fileName": "update_data.bal",
     "nodes": [
       {
-        "id": "52732",
+        "id": "54375",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "update_data.bal",
             "startLine": {
               "line": 21,
-              "offset": 0
+              "offset": 53
             },
             "endLine": {
               "line": 26,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -13,7 +13,7 @@
     "fileName": "clients.bal",
     "nodes": [
       {
-        "id": "45137",
+        "id": "46315",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "clients.bal",
             "startLine": {
               "line": 13,
-              "offset": 0
+              "offset": 38
             },
             "endLine": {
               "line": 29,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment1.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "31900",
+        "id": "33419",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 49
             },
             "endLine": {
               "line": 5,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment10.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "118328",
+        "id": "119692",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 87,
-              "offset": 0
+              "offset": 44
             },
             "endLine": {
               "line": 96,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment11.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "129240",
+        "id": "130449",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 98,
-              "offset": 0
+              "offset": 39
             },
             "endLine": {
               "line": 107,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment12.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "139966",
+        "id": "140927",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 109,
-              "offset": 0
+              "offset": 31
             },
             "endLine": {
               "line": 112,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment13.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment13.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "145515",
+        "id": "146848",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 114,
-              "offset": 0
+              "offset": 43
             },
             "endLine": {
               "line": 136,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment2.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "38906",
+        "id": "40177",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 7,
-              "offset": 0
+              "offset": 41
             },
             "endLine": {
               "line": 14,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment3.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "47741",
+        "id": "49012",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 16,
-              "offset": 0
+              "offset": 41
             },
             "endLine": {
               "line": 20,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment4.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "53724",
+        "id": "54995",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 22,
-              "offset": 0
+              "offset": 41
             },
             "endLine": {
               "line": 27,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment5.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "60978",
+        "id": "62280",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 29,
-              "offset": 0
+              "offset": 42
             },
             "endLine": {
               "line": 44,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment6.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "77687",
+        "id": "78989",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 46,
-              "offset": 0
+              "offset": 42
             },
             "endLine": {
               "line": 56,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment7.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "89560",
+        "id": "90862",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 58,
-              "offset": 0
+              "offset": 42
             },
             "endLine": {
               "line": 67,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment8.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "100410",
+        "id": "101557",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 69,
-              "offset": 0
+              "offset": 37
             },
             "endLine": {
               "line": 76,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment9.json
@@ -9,12 +9,11 @@
   },
   "source": "comment.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "comment.bal",
     "nodes": [
       {
-        "id": "109338",
+        "id": "111167",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "comment.bal",
             "startLine": {
               "line": 78,
-              "offset": 0
+              "offset": 59
             },
             "endLine": {
               "line": 85,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
@@ -13,7 +13,7 @@
     "fileName": "main.bal",
     "nodes": [
       {
-        "id": "40394",
+        "id": "41107",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "main.bal",
             "startLine": {
               "line": 8,
-              "offset": 0
+              "offset": 23
             },
             "endLine": {
               "line": 31,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
@@ -13,7 +13,7 @@
     "fileName": "error_handler.bal",
     "nodes": [
       {
-        "id": "37081",
+        "id": "38042",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "error_handler.bal",
             "startLine": {
               "line": 5,
-              "offset": 4
+              "offset": 35
             },
             "endLine": {
               "line": 13,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
@@ -13,7 +13,7 @@
     "fileName": "error_handler.bal",
     "nodes": [
       {
-        "id": "47187",
+        "id": "48179",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "error_handler.bal",
             "startLine": {
               "line": 15,
-              "offset": 4
+              "offset": 36
             },
             "endLine": {
               "line": 29,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
@@ -9,12 +9,11 @@
   },
   "source": "error_handler.bal",
   "description": "Tests a error handler",
-  "forceAssign": false,
   "diagram": {
     "fileName": "error_handler.bal",
     "nodes": [
       {
-        "id": "62842",
+        "id": "64392",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "error_handler.bal",
             "startLine": {
               "line": 31,
-              "offset": 4
+              "offset": 54
             },
             "endLine": {
               "line": 38,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler4.json
@@ -9,12 +9,11 @@
   },
   "source": "fail.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "fail.bal",
     "nodes": [
       {
-        "id": "35899",
+        "id": "37201",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "fail.bal",
             "startLine": {
               "line": 4,
-              "offset": 0
+              "offset": 42
             },
             "endLine": {
               "line": 10,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler5.json
@@ -9,12 +9,11 @@
   },
   "source": "fail.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "fail.bal",
     "nodes": [
       {
-        "id": "43835",
+        "id": "45137",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "fail.bal",
             "startLine": {
               "line": 12,
-              "offset": 0
+              "offset": 42
             },
             "endLine": {
               "line": 18,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler6.json
@@ -9,12 +9,11 @@
   },
   "source": "fail.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "fail.bal",
     "nodes": [
       {
-        "id": "51802",
+        "id": "53104",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "fail.bal",
             "startLine": {
               "line": 20,
-              "offset": 0
+              "offset": 42
             },
             "endLine": {
               "line": 27,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags1.json
@@ -13,7 +13,7 @@
     "fileName": "flags.bal",
     "nodes": [
       {
-        "id": "34969",
+        "id": "36147",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "flags.bal",
             "startLine": {
               "line": 3,
-              "offset": 0
+              "offset": 38
             },
             "endLine": {
               "line": 11,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags2.json
@@ -9,12 +9,11 @@
   },
   "source": "flags.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "flags.bal",
     "nodes": [
       {
-        "id": "45823",
+        "id": "48923",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "flags.bal",
             "startLine": {
               "line": 14,
-              "offset": 4
+              "offset": 104
             },
             "endLine": {
               "line": 16,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags3.json
@@ -9,12 +9,11 @@
   },
   "source": "flags.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "flags.bal",
     "nodes": [
       {
-        "id": "51775",
+        "id": "52829",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "flags.bal",
             "startLine": {
               "line": 20,
-              "offset": 4
+              "offset": 38
             },
             "endLine": {
               "line": 22,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -13,7 +13,7 @@
     "fileName": "function_call.bal",
     "nodes": [
       {
-        "id": "52829",
+        "id": "55154",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "function_call.bal",
             "startLine": {
               "line": 21,
-              "offset": 4
+              "offset": 79
             },
             "endLine": {
               "line": 25,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach1.json
@@ -13,7 +13,7 @@
     "fileName": "foreach.bal",
     "nodes": [
       {
-        "id": "31900",
+        "id": "32861",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "foreach.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 31
             },
             "endLine": {
               "line": 5,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach2.json
@@ -13,7 +13,7 @@
     "fileName": "foreach.bal",
     "nodes": [
       {
-        "id": "31900",
+        "id": "32861",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "foreach.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 31
             },
             "endLine": {
               "line": 5,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach3.json
@@ -13,7 +13,7 @@
     "fileName": "foreach.bal",
     "nodes": [
       {
-        "id": "45850",
+        "id": "47586",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "foreach.bal",
             "startLine": {
               "line": 14,
-              "offset": 0
+              "offset": 56
             },
             "endLine": {
               "line": 21,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach4.json
@@ -13,7 +13,7 @@
     "fileName": "foreach.bal",
     "nodes": [
       {
-        "id": "54778",
+        "id": "56514",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "foreach.bal",
             "startLine": {
               "line": 23,
-              "offset": 0
+              "offset": 56
             },
             "endLine": {
               "line": 30,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach5.json
@@ -13,7 +13,7 @@
     "fileName": "foreach.bal",
     "nodes": [
       {
-        "id": "63644",
+        "id": "65070",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "foreach.bal",
             "startLine": {
               "line": 32,
-              "offset": 0
+              "offset": 46
             },
             "endLine": {
               "line": 37,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -13,7 +13,7 @@
     "fileName": "function_call.bal",
     "nodes": [
       {
-        "id": "52829",
+        "id": "55154",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "function_call.bal",
             "startLine": {
               "line": 21,
-              "offset": 4
+              "offset": 79
             },
             "endLine": {
               "line": 25,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
@@ -13,7 +13,7 @@
     "fileName": "function_call.bal",
     "nodes": [
       {
-        "id": "98581",
+        "id": "99294",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "function_call.bal",
             "startLine": {
               "line": 67,
-              "offset": 0
+              "offset": 23
             },
             "endLine": {
               "line": 79,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event1.json
@@ -9,12 +9,11 @@
   },
   "source": "http_api_event_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_api_event_node.bal",
     "nodes": [
       {
-        "id": "40880",
+        "id": "42182",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_api_event_node.bal",
             "startLine": {
               "line": 9,
-              "offset": 4
+              "offset": 46
             },
             "endLine": {
               "line": 9,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event2.json
@@ -9,12 +9,11 @@
   },
   "source": "http_api_event_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_api_event_node.bal",
     "nodes": [
       {
-        "id": "41880",
+        "id": "43523",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_api_event_node.bal",
             "startLine": {
               "line": 10,
-              "offset": 4
+              "offset": 57
             },
             "endLine": {
               "line": 10,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event3.json
@@ -9,12 +9,11 @@
   },
   "source": "http_api_event_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "http_api_event_node.bal",
     "nodes": [
       {
-        "id": "43808",
+        "id": "46009",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "http_api_event_node.bal",
             "startLine": {
               "line": 12,
-              "offset": 4
+              "offset": 75
             },
             "endLine": {
               "line": 13,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "45978",
+        "id": "47311",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 14,
-              "offset": 4
+              "offset": 47
             },
             "endLine": {
               "line": 21,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "164119",
+        "id": "165979",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 133,
-              "offset": 4
+              "offset": 64
             },
             "endLine": {
               "line": 143,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "55030",
+        "id": "56766",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 23,
-              "offset": 4
+              "offset": 60
             },
             "endLine": {
               "line": 34,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "68081",
+        "id": "69755",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 36,
-              "offset": 4
+              "offset": 58
             },
             "endLine": {
               "line": 52,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "85937",
+        "id": "87177",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 54,
-              "offset": 4
+              "offset": 44
             },
             "endLine": {
               "line": 70,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "103545",
+        "id": "105498",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 72,
-              "offset": 4
+              "offset": 67
             },
             "endLine": {
               "line": 80,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "113434",
+        "id": "115263",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 82,
-              "offset": 4
+              "offset": 63
             },
             "endLine": {
               "line": 89,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "122517",
+        "id": "124346",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 91,
-              "offset": 4
+              "offset": 63
             },
             "endLine": {
               "line": 103,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "136467",
+        "id": "138327",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 105,
-              "offset": 4
+              "offset": 64
             },
             "endLine": {
               "line": 119,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
@@ -9,12 +9,11 @@
   },
   "source": "if_node.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "if_node.bal",
     "nodes": [
       {
-        "id": "152215",
+        "id": "154199",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "if_node.bal",
             "startLine": {
               "line": 121,
-              "offset": 4
+              "offset": 68
             },
             "endLine": {
               "line": 131,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock1.json
@@ -9,12 +9,11 @@
   },
   "source": "lock.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "lock.bal",
     "nodes": [
       {
-        "id": "31869",
+        "id": "32520",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "lock.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 21
             },
             "endLine": {
               "line": 4,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock2.json
@@ -9,12 +9,11 @@
   },
   "source": "lock.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "lock.bal",
     "nodes": [
       {
-        "id": "37914",
+        "id": "38565",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "lock.bal",
             "startLine": {
               "line": 6,
-              "offset": 0
+              "offset": 21
             },
             "endLine": {
               "line": 13,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock3.json
@@ -9,12 +9,11 @@
   },
   "source": "lock.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "lock.bal",
     "nodes": [
       {
-        "id": "46811",
+        "id": "48237",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "lock.bal",
             "startLine": {
               "line": 15,
-              "offset": 0
+              "offset": 46
             },
             "endLine": {
               "line": 21,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock4.json
@@ -9,12 +9,11 @@
   },
   "source": "lock.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "lock.bal",
     "nodes": [
       {
-        "id": "54747",
+        "id": "56173",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "lock.bal",
             "startLine": {
               "line": 23,
-              "offset": 0
+              "offset": 46
             },
             "endLine": {
               "line": 29,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match1.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "42165",
+        "id": "43963",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 10,
-              "offset": 4
+              "offset": 62
             },
             "endLine": {
               "line": 22,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match10.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "228072",
+        "id": "230366",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 197,
-              "offset": 4
+              "offset": 78
             },
             "endLine": {
               "line": 222,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match11.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "254515",
+        "id": "256499",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 224,
-              "offset": 4
+              "offset": 68
             },
             "endLine": {
               "line": 238,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
@@ -13,7 +13,7 @@
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "270418",
+        "id": "272619",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 240,
-              "offset": 4
+              "offset": 75
             },
             "endLine": {
               "line": 255,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match2.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "56239",
+        "id": "58068",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 24,
-              "offset": 4
+              "offset": 63
             },
             "endLine": {
               "line": 42,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match3.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "76203",
+        "id": "77970",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 44,
-              "offset": 4
+              "offset": 61
             },
             "endLine": {
               "line": 66,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match4.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "100011",
+        "id": "101716",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 68,
-              "offset": 4
+              "offset": 59
             },
             "endLine": {
               "line": 90,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match5.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "123602",
+        "id": "125555",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 92,
-              "offset": 4
+              "offset": 67
             },
             "endLine": {
               "line": 107,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match6.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "140373",
+        "id": "142202",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 109,
-              "offset": 4
+              "offset": 63
             },
             "endLine": {
               "line": 121,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match7.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "154478",
+        "id": "156307",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 123,
-              "offset": 4
+              "offset": 63
             },
             "endLine": {
               "line": 142,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match8.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "175527",
+        "id": "177387",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 144,
-              "offset": 4
+              "offset": 64
             },
             "endLine": {
               "line": 170,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match9.json
@@ -9,12 +9,11 @@
   },
   "source": "match.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "match.bal",
     "nodes": [
       {
-        "id": "203210",
+        "id": "205659",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "match.bal",
             "startLine": {
               "line": 172,
-              "offset": 4
+              "offset": 83
             },
             "endLine": {
               "line": 195,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
@@ -9,12 +9,11 @@
   },
   "source": "nested_node.bal",
   "description": "Tests a diagram flow with nested nodes",
-  "forceAssign": false,
   "diagram": {
     "fileName": "nested_node.bal",
     "nodes": [
       {
-        "id": "36957",
+        "id": "38352",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "nested_node.bal",
             "startLine": {
               "line": 5,
-              "offset": 4
+              "offset": 49
             },
             "endLine": {
               "line": 9,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
@@ -9,12 +9,11 @@
   },
   "source": "nested_node.bal",
   "description": "Tests a diagram flow with nested nodes",
-  "forceAssign": false,
   "diagram": {
     "fileName": "nested_node.bal",
     "nodes": [
       {
-        "id": "43064",
+        "id": "44924",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "nested_node.bal",
             "startLine": {
               "line": 11,
-              "offset": 4
+              "offset": 64
             },
             "endLine": {
               "line": 20,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
@@ -9,12 +9,11 @@
   },
   "source": "nested_node.bal",
   "description": "Tests a diagram flow with nested nodes",
-  "forceAssign": false,
   "diagram": {
     "fileName": "nested_node.bal",
     "nodes": [
       {
-        "id": "53821",
+        "id": "54844",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "nested_node.bal",
             "startLine": {
               "line": 22,
-              "offset": 4
+              "offset": 37
             },
             "endLine": {
               "line": 26,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
@@ -9,12 +9,11 @@
   },
   "source": "nested_node.bal",
   "description": "Tests a diagram flow with nested nodes",
-  "forceAssign": false,
   "diagram": {
     "fileName": "nested_node.bal",
     "nodes": [
       {
-        "id": "59990",
+        "id": "61385",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "nested_node.bal",
             "startLine": {
               "line": 28,
-              "offset": 4
+              "offset": 49
             },
             "endLine": {
               "line": 39,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
@@ -9,12 +9,11 @@
   },
   "source": "nested_node.bal",
   "description": "Tests a diagram flow with nested nodes",
-  "forceAssign": false,
   "diagram": {
     "fileName": "nested_node.bal",
     "nodes": [
       {
-        "id": "72917",
+        "id": "74281",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "nested_node.bal",
             "startLine": {
               "line": 41,
-              "offset": 4
+              "offset": 48
             },
             "endLine": {
               "line": 53,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
@@ -13,7 +13,7 @@
     "fileName": "new_connection.bal",
     "nodes": [
       {
-        "id": "37790",
+        "id": "38937",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "new_connection.bal",
             "startLine": {
               "line": 6,
-              "offset": 0
+              "offset": 37
             },
             "endLine": {
               "line": 9,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
@@ -13,7 +13,7 @@
     "fileName": "new_connection.bal",
     "nodes": [
       {
-        "id": "45726",
+        "id": "46873",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "new_connection.bal",
             "startLine": {
               "line": 14,
-              "offset": 0
+              "offset": 37
             },
             "endLine": {
               "line": 17,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
@@ -9,12 +9,11 @@
   },
   "source": "new_connection.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "new_connection.bal",
     "nodes": [
       {
-        "id": "57727",
+        "id": "58533",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "new_connection.bal",
             "startLine": {
               "line": 26,
-              "offset": 4
+              "offset": 30
             },
             "endLine": {
               "line": 28,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/panic1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/panic1.json
@@ -9,12 +9,11 @@
   },
   "source": "panic.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "panic.bal",
     "nodes": [
       {
-        "id": "35775",
+        "id": "36457",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "panic.bal",
             "startLine": {
               "line": 4,
-              "offset": 0
+              "offset": 22
             },
             "endLine": {
               "line": 6,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/panic2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/panic2.json
@@ -9,12 +9,11 @@
   },
   "source": "panic.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "panic.bal",
     "nodes": [
       {
-        "id": "39743",
+        "id": "40425",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "panic.bal",
             "startLine": {
               "line": 8,
-              "offset": 0
+              "offset": 22
             },
             "endLine": {
               "line": 10,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/panic3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/panic3.json
@@ -9,12 +9,11 @@
   },
   "source": "panic.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "panic.bal",
     "nodes": [
       {
-        "id": "43711",
+        "id": "44393",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "panic.bal",
             "startLine": {
               "line": 12,
-              "offset": 0
+              "offset": 22
             },
             "endLine": {
               "line": 14,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/panic4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/panic4.json
@@ -9,12 +9,11 @@
   },
   "source": "panic.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "panic.bal",
     "nodes": [
       {
-        "id": "47710",
+        "id": "48392",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "panic.bal",
             "startLine": {
               "line": 16,
-              "offset": 0
+              "offset": 22
             },
             "endLine": {
               "line": 19,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
@@ -9,12 +9,11 @@
   },
   "source": "simple_flow.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "simple_flow.bal",
     "nodes": [
       {
-        "id": "38073",
+        "id": "40305",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "simple_flow.bal",
             "startLine": {
               "line": 6,
-              "offset": 4
+              "offset": 76
             },
             "endLine": {
               "line": 14,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/start1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/start1.json
@@ -9,12 +9,11 @@
   },
   "source": "start.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "start.bal",
     "nodes": [
       {
-        "id": "31807",
+        "id": "32489",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "start.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 22
             },
             "endLine": {
               "line": 2,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/start2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/start2.json
@@ -13,7 +13,7 @@
     "fileName": "start.bal",
     "nodes": [
       {
-        "id": "51709",
+        "id": "52391",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "start.bal",
             "startLine": {
               "line": 20,
-              "offset": 0
+              "offset": 22
             },
             "endLine": {
               "line": 24,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/stop1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/stop1.json
@@ -9,12 +9,11 @@
   },
   "source": "stop.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "stop.bal",
     "nodes": [
       {
-        "id": "31807",
+        "id": "32458",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "stop.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 21
             },
             "endLine": {
               "line": 2,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/stop2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/stop2.json
@@ -9,12 +9,11 @@
   },
   "source": "stop.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "stop.bal",
     "nodes": [
       {
-        "id": "35930",
+        "id": "37139",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "stop.bal",
             "startLine": {
               "line": 4,
-              "offset": 0
+              "offset": 39
             },
             "endLine": {
               "line": 11,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction2.json
@@ -9,12 +9,11 @@
   },
   "source": "transaction.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "transaction.bal",
     "nodes": [
       {
-        "id": "38038",
+        "id": "39619",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "transaction.bal",
             "startLine": {
               "line": 6,
-              "offset": 0
+              "offset": 51
             },
             "endLine": {
               "line": 17,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction3.json
@@ -9,12 +9,11 @@
   },
   "source": "transaction.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "transaction.bal",
     "nodes": [
       {
-        "id": "50810",
+        "id": "52143",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "transaction.bal",
             "startLine": {
               "line": 19,
-              "offset": 0
+              "offset": 43
             },
             "endLine": {
               "line": 26,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction4.json
@@ -9,12 +9,11 @@
   },
   "source": "transaction.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "transaction.bal",
     "nodes": [
       {
-        "id": "59707",
+        "id": "61226",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "transaction.bal",
             "startLine": {
               "line": 28,
-              "offset": 0
+              "offset": 49
             },
             "endLine": {
               "line": 34,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction5.json
@@ -9,12 +9,11 @@
   },
   "source": "transaction.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "transaction.bal",
     "nodes": [
       {
-        "id": "67643",
+        "id": "69162",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "transaction.bal",
             "startLine": {
               "line": 36,
-              "offset": 0
+              "offset": 49
             },
             "endLine": {
               "line": 42,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction6.json
@@ -9,12 +9,11 @@
   },
   "source": "transaction.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "transaction.bal",
     "nodes": [
       {
-        "id": "75672",
+        "id": "77191",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "transaction.bal",
             "startLine": {
               "line": 44,
-              "offset": 0
+              "offset": 49
             },
             "endLine": {
               "line": 53,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction8.json
@@ -9,12 +9,11 @@
   },
   "source": "rollback.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "rollback.bal",
     "nodes": [
       {
-        "id": "31993",
+        "id": "33388",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "rollback.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 45
             },
             "endLine": {
               "line": 8,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction9.json
@@ -9,12 +9,11 @@
   },
   "source": "rollback.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "rollback.bal",
     "nodes": [
       {
-        "id": "41913",
+        "id": "43742",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "rollback.bal",
             "startLine": {
               "line": 10,
-              "offset": 0
+              "offset": 59
             },
             "endLine": {
               "line": 18,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable2.json
@@ -9,12 +9,11 @@
   },
   "source": "new_data.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "new_data.bal",
     "nodes": [
       {
-        "id": "43742",
+        "id": "44641",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "new_data.bal",
             "startLine": {
               "line": 12,
-              "offset": 0
+              "offset": 29
             },
             "endLine": {
               "line": 15,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable3.json
@@ -13,7 +13,7 @@
     "fileName": "new_data.bal",
     "nodes": [
       {
-        "id": "48671",
+        "id": "49539",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "new_data.bal",
             "startLine": {
               "line": 17,
-              "offset": 0
+              "offset": 28
             },
             "endLine": {
               "line": 19,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable4.json
@@ -13,7 +13,7 @@
     "fileName": "new_data.bal",
     "nodes": [
       {
-        "id": "52701",
+        "id": "53507",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "new_data.bal",
             "startLine": {
               "line": 21,
-              "offset": 0
+              "offset": 26
             },
             "endLine": {
               "line": 25,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable5.json
@@ -13,7 +13,7 @@
     "fileName": "new_data.bal",
     "nodes": [
       {
-        "id": "58591",
+        "id": "60234",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "new_data.bal",
             "startLine": {
               "line": 27,
-              "offset": 0
+              "offset": 53
             },
             "endLine": {
               "line": 29,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable6.json
@@ -13,7 +13,7 @@
     "fileName": "new_data.bal",
     "nodes": [
       {
-        "id": "62621",
+        "id": "64264",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "new_data.bal",
             "startLine": {
               "line": 31,
-              "offset": 0
+              "offset": 53
             },
             "endLine": {
               "line": 35,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable7.json
@@ -13,7 +13,7 @@
     "fileName": "new_data.bal",
     "nodes": [
       {
-        "id": "68728",
+        "id": "70433",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "new_data.bal",
             "startLine": {
               "line": 37,
-              "offset": 0
+              "offset": 55
             },
             "endLine": {
               "line": 46,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -13,7 +13,7 @@
     "fileName": "while.bal",
     "nodes": [
       {
-        "id": "37205",
+        "id": "38445",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "while.bal",
             "startLine": {
               "line": 5,
-              "offset": 4
+              "offset": 44
             },
             "endLine": {
               "line": 17,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
@@ -9,12 +9,11 @@
   },
   "source": "while.bal",
   "description": "Tests a simple diagram flow",
-  "forceAssign": false,
   "diagram": {
     "fileName": "while.bal",
     "nodes": [
       {
-        "id": "50814",
+        "id": "51806",
         "metadata": {
           "label": "Start"
         },
@@ -24,7 +23,7 @@
             "fileName": "while.bal",
             "startLine": {
               "line": 19,
-              "offset": 4
+              "offset": 36
             },
             "endLine": {
               "line": 22,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -13,7 +13,7 @@
     "fileName": "while.bal",
     "nodes": [
       {
-        "id": "55991",
+        "id": "57262",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "while.bal",
             "startLine": {
               "line": 24,
-              "offset": 4
+              "offset": 45
             },
             "endLine": {
               "line": 34,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -13,7 +13,7 @@
     "fileName": "while.bal",
     "nodes": [
       {
-        "id": "67895",
+        "id": "69135",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "while.bal",
             "startLine": {
               "line": 36,
-              "offset": 4
+              "offset": 44
             },
             "endLine": {
               "line": 46,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
@@ -13,7 +13,7 @@
     "fileName": "while.bal",
     "nodes": [
       {
-        "id": "80171",
+        "id": "82403",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "while.bal",
             "startLine": {
               "line": 48,
-              "offset": 4
+              "offset": 76
             },
             "endLine": {
               "line": 70,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -13,7 +13,7 @@
     "fileName": "while.bal",
     "nodes": [
       {
-        "id": "103700",
+        "id": "104971",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "while.bal",
             "startLine": {
               "line": 72,
-              "offset": 4
+              "offset": 45
             },
             "endLine": {
               "line": 85,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -13,7 +13,7 @@
     "fileName": "while.bal",
     "nodes": [
       {
-        "id": "118580",
+        "id": "119820",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "while.bal",
             "startLine": {
               "line": 87,
-              "offset": 4
+              "offset": 44
             },
             "endLine": {
               "line": 100,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -13,7 +13,7 @@
     "fileName": "while.bal",
     "nodes": [
       {
-        "id": "133553",
+        "id": "134948",
         "metadata": {
           "label": "Start"
         },
@@ -23,7 +23,7 @@
             "fileName": "while.bal",
             "startLine": {
               "line": 102,
-              "offset": 4
+              "offset": 49
             },
             "endLine": {
               "line": 118,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler1.json
@@ -19,7 +19,7 @@
     "fileName": "service.bal",
     "nodes": [
       {
-        "id": "36089",
+        "id": "38135",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "service.bal",
             "startLine": {
               "line": 4,
-              "offset": 4
+              "offset": 70
             },
             "endLine": {
               "line": 12,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler2.json
@@ -19,7 +19,7 @@
     "fileName": "service.bal",
     "nodes": [
       {
-        "id": "36089",
+        "id": "38135",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "service.bal",
             "startLine": {
               "line": 4,
-              "offset": 4
+              "offset": 70
             },
             "endLine": {
               "line": 12,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if1.json
@@ -19,7 +19,7 @@
     "fileName": "if.bal",
     "nodes": [
       {
-        "id": "31931",
+        "id": "32768",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "if.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 27
             },
             "endLine": {
               "line": 6,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if2.json
@@ -19,7 +19,7 @@
     "fileName": "if.bal",
     "nodes": [
       {
-        "id": "31931",
+        "id": "32768",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "if.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 27
             },
             "endLine": {
               "line": 6,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if3.json
@@ -19,7 +19,7 @@
     "fileName": "if.bal",
     "nodes": [
       {
-        "id": "31962",
+        "id": "32799",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "if.bal",
             "startLine": {
               "line": 0,
-              "offset": 0
+              "offset": 27
             },
             "endLine": {
               "line": 7,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if4.json
@@ -19,7 +19,7 @@
     "fileName": "if.bal",
     "nodes": [
       {
-        "id": "38100",
+        "id": "38565",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "if.bal",
             "startLine": {
               "line": 6,
-              "offset": 0
+              "offset": 15
             },
             "endLine": {
               "line": 19,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if5.json
@@ -19,7 +19,7 @@
     "fileName": "if.bal",
     "nodes": [
       {
-        "id": "38100",
+        "id": "38565",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "if.bal",
             "startLine": {
               "line": 6,
-              "offset": 0
+              "offset": 15
             },
             "endLine": {
               "line": 19,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if6.json
@@ -19,7 +19,7 @@
     "fileName": "if.bal",
     "nodes": [
       {
-        "id": "38131",
+        "id": "38596",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "if.bal",
             "startLine": {
               "line": 6,
-              "offset": 0
+              "offset": 15
             },
             "endLine": {
               "line": 20,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if7.json
@@ -19,7 +19,7 @@
     "fileName": "if.bal",
     "nodes": [
       {
-        "id": "38193",
+        "id": "38658",
         "metadata": {
           "label": "Start"
         },
@@ -29,7 +29,7 @@
             "fileName": "if.bal",
             "startLine": {
               "line": 6,
-              "offset": 0
+              "offset": 15
             },
             "endLine": {
               "line": 22,


### PR DESCRIPTION
## Purpose
Previously, the line range of the start node covered the entire function. Now, it's modified to focus on the function body. This ensures that when a new node is added, it will be inserted as the first statement inside the function rather than outside the function definition.