### PR TITLE
Provide an LS API to retrieve types for a given position

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class is responsible for generating types from the semantic model.
+ */
+public class TypesGenerator {
+
+    private final SemanticModel semanticModel;
+    private static final List<String> DEFAULT_TYPES =
+            List.of("int", "string", "float", "boolean", "decimal", "xml", "error", "function", "future", "typedesc",
+                    "handle", "stream", "any", "anydata", "stream", "never", "readonly", "json", "byte");
+    private final Gson gson;
+
+    public TypesGenerator(SemanticModel semanticModel) {
+        this.semanticModel = semanticModel;
+        this.gson = new Gson();
+    }
+
+    public JsonArray getTypes() {
+        List<String> visibleTypes = semanticModel.moduleSymbols().stream()
+                .filter(symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION)
+                .flatMap(symbol -> symbol.getName().stream())
+                .collect(Collectors.toCollection(ArrayList::new));
+        visibleTypes.addAll(DEFAULT_TYPES);
+        return gson.toJsonTree(visibleTypes).getAsJsonArray();
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/response/ExpressionEditorTypeResponse.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/response/ExpressionEditorTypeResponse.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension.response;
+
+import com.google.gson.JsonArray;
+
+/**
+ * This class represents the response for the expression editor types.
+ *
+ * @since 1.4.0
+ */
+public class ExpressionEditorTypeResponse extends AbstractFlowModelResponse {
+
+    private JsonArray types;
+
+    public void setTypes(JsonArray types) {
+        this.types = types;
+    }
+
+    public JsonArray types() {
+        return types;
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorTypesTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorTypesTest.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.ballerina.flowmodelgenerator.extension.request.VisibleVariableTypeRequest;
+import io.ballerina.tools.text.LinePosition;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Tests for the expression editor types service.
+ *
+ * @since 1.4.0
+ */
+public class ExpressionEditorTypesTest extends AbstractLSTest {
+
+    @Test(dataProvider = "data-provider")
+    public void test(Path config) throws IOException {
+        Path configJsonPath = configDir.resolve(config);
+        TestConfig testConfig = gson.fromJson(Files.newBufferedReader(configJsonPath), TestConfig.class);
+
+        VisibleVariableTypeRequest request = new VisibleVariableTypeRequest(
+                sourceDir.resolve(testConfig.source()).toAbsolutePath().toString(), testConfig.position());
+        JsonObject response = getResponse(request);
+
+        JsonArray actualExpressionTypes = response.get("types").getAsJsonArray();
+        if (!actualExpressionTypes.equals(testConfig.types())) {
+            TestConfig updatedConfig = new TestConfig(testConfig.description(), testConfig.source(),
+                    testConfig.position(), actualExpressionTypes);
+            compareJsonElements(actualExpressionTypes, testConfig.types());
+//            updateConfig(configJsonPath, updatedConfig);
+            Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
+        }
+    }
+
+    @Override
+    protected String getResourceDir() {
+        return "types";
+    }
+
+    @Override
+    protected Class<? extends AbstractLSTest> clazz() {
+        return ExpressionEditorTypesTest.class;
+    }
+
+    @Override
+    protected String getApiName() {
+        return "types";
+    }
+
+    @Override
+    protected String getServiceName() {
+        return "expressionEditor";
+    }
+
+    private record TestConfig(String description, String source, LinePosition position, JsonArray types) {
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/testng.xml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/testng.xml
@@ -34,6 +34,7 @@ under the License.
             <class name="io.ballerina.flowmodelgenerator.extension.CopilotContextTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.ExpressionEditorCompletionTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.ExpressionEditorSignatureTest"/>
+            <class name="io.ballerina.flowmodelgenerator.extension.ExpressionEditorTypesTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.ServiceGeneratorTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.VisibleVariableTypesTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.ConfigVariablesTest"/>

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
@@ -1,0 +1,36 @@
+{
+  "description": "",
+  "source": "data_mapper/main.bal",
+  "position": {
+    "line": 16,
+    "offset": 0
+  },
+  "types": [
+    "Input",
+    "Output",
+    "Location",
+    "Address",
+    "Employee",
+    "Person",
+    "Admission",
+    "int",
+    "string",
+    "float",
+    "boolean",
+    "decimal",
+    "xml",
+    "error",
+    "function",
+    "future",
+    "typedesc",
+    "handle",
+    "stream",
+    "any",
+    "anydata",
+    "stream",
+    "never",
+    "readonly",
+    "json",
+    "byte"
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
@@ -1,0 +1,36 @@
+{
+  "description": "",
+  "source": "data_mapper/service.bal",
+  "position": {
+    "line": 14,
+    "offset": 0
+  },
+  "types": [
+    "Input",
+    "Output",
+    "Location",
+    "Address",
+    "Employee",
+    "Person",
+    "Admission",
+    "int",
+    "string",
+    "float",
+    "boolean",
+    "decimal",
+    "xml",
+    "error",
+    "function",
+    "future",
+    "typedesc",
+    "handle",
+    "stream",
+    "any",
+    "anydata",
+    "stream",
+    "never",
+    "readonly",
+    "json",
+    "byte"
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "nipunaf"
+name = "new_connection1"
+version = "0.1.0"
+distribution = "2201.9.2"
+
+[build-options]
+observabilityIncluded = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/data_mappings.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/data_mappings.bal
@@ -1,0 +1,11 @@
+
+function transform(Person person, Admission admission) returns Employee => {
+    name: person.name,
+    empId: admission.empId,
+    email: person.email,
+    location: {
+        city: person.address.city,
+        country: person.address.country
+    }
+};
+

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/main.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/main.bal
@@ -1,0 +1,27 @@
+import ballerina/http;
+
+http:Client cl = check new ("http://localhost:9090");
+boolean w = false;
+
+public function main() {
+    int x = 32;
+    while x < 50 {
+        boolean w = x % 2 == 0;
+        if (w) {
+            int y = 12;
+        } else {
+            string z = "hello";
+            do {
+                if z.length() == x {
+                    Address address = {houseNo: "10", line1: "foo", line2: "bar", city: "Colombo", country: "Sri Lanka"};
+                    
+                } else {
+                    fail error("error");
+                }
+            } on fail {
+                break;
+            }
+        }
+        x += 2;
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/service.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/service.bal
@@ -1,0 +1,32 @@
+import ballerina/http;
+
+configurable string serviceName = "DataMapperService";
+configurable int servicePort = 9091;
+configurable Input configInput = ?;
+configurable table<Input> key(name) configTable = table [
+    {name: "Alice", age: 25},
+    {name: "Bob", age: 28}
+];
+
+service /p1 on new http:Listener(9091) {
+    resource function get greeting() returns json|http:InternalServerError {
+        do {
+            Input localInput = {name: "John", age: 30};
+
+        } on fail error e {
+            return http:INTERNAL_SERVER_ERROR;
+        }
+    }
+}
+
+type Input record {
+    readonly string name;
+    int age;
+};
+
+type Output record {
+    string name;
+    int age;
+};
+
+Input moduleInput = {name: "John", age: 30};

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/types.bal
@@ -1,0 +1,30 @@
+type Location record {|
+    string city;
+    string country;
+|};
+
+type Address record {|
+    string houseNo;
+    string line1;
+    string line2;
+    string city;
+    string country;
+|};
+
+type Employee record {|
+    string name;
+    string empId;
+    string email;
+    Location location;
+|};
+
+type Person record {|
+    string name;
+    string email;
+    Address address;
+|};
+
+type Admission record {
+    string empId;
+    string admissionDate;
+};


### PR DESCRIPTION
## Purpose
Using the completions API to get visible types can be inconsistent and challenging. To address this, the `expressionEditor/types` API is introduced to fetch the visible types for the specified cursor position.