### PR TITLE
Remove the central API usage from the `getFlowModel` API

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -343,10 +343,6 @@ class CodeAnalyzer extends NodeVisitor {
         }
 
         String moduleName = CommonUtils.getModuleName(typeSymbol.get());
-        String packageName = CommonUtils.getPackageName(typeSymbol.get());
-        String orgName = CommonUtils.getOrgName(typeSymbol.get());
-        String version = CommonUtils.getVersion(typeSymbol.get());
-        String icon = CommonUtils.getIcon(orgName, moduleName, version);
 
         if (typeSymbol.get().typeKind() != TypeDescKind.TYPE_REFERENCE) {
             return;
@@ -366,14 +362,12 @@ class CodeAnalyzer extends NodeVisitor {
                 initMethodSymbol.get().documentation().map(Documentation::parameterMap).orElse(Map.of());
 
         startNode(NodeKind.NEW_CONNECTION)
+                .symbolInfo(initMethodSymbol.get())
                 .metadata()
                     .label(moduleName)
                     .description(description)
-                    .icon(icon)
                     .stepOut()
                 .codedata()
-                    .org(orgName)
-                    .module(packageName)
                     .object("Client")
                     .symbol("init")
                     .stepOut()

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CommonUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CommonUtils.java
@@ -324,4 +324,16 @@ public class CommonUtils {
                         project.sourceRoot().resolve(location.lineRange().fileName()));
         return project.currentPackage().getDefaultModule().document(documentId);
     }
+
+    public static String getVersion(Symbol symbol) {
+        return symbol.getModule().map(module -> module.id().version()).orElse("0.0.0");
+    }
+
+    public static String getPackageName(Symbol symbol) {
+        return symbol.getModule().map(module -> module.id().packageName()).orElse(".");
+    }
+
+    public static String getIcon(String org, String module, String version) {
+        return String.format("https://bcentral-packageicons.azureedge.net/images/%s_%s_%s.png", org, module, version);
+    }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CommonUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CommonUtils.java
@@ -324,16 +324,4 @@ public class CommonUtils {
                         project.sourceRoot().resolve(location.lineRange().fileName()));
         return project.currentPackage().getDefaultModule().document(documentId);
     }
-
-    public static String getVersion(Symbol symbol) {
-        return symbol.getModule().map(module -> module.id().version()).orElse("0.0.0");
-    }
-
-    public static String getPackageName(Symbol symbol) {
-        return symbol.getModule().map(module -> module.id().packageName()).orElse(".");
-    }
-
-    public static String getIcon(String org, String module, String version) {
-        return String.format("https://bcentral-packageicons.azureedge.net/images/%s_%s_%s.png", org, module, version);
-    }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeBuilder.java
@@ -18,9 +18,12 @@
 
 package io.ballerina.flowmodelgenerator.core.model;
 
+import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.CheckExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
@@ -107,6 +110,8 @@ public abstract class NodeBuilder {
     protected FlowNode cachedFlowNode;
     protected String defaultModuleName;
 
+    private static final String CENTRAL_ICON_URL = "https://bcentral-packageicons.azureedge.net/images/%s_%s_%s.png";
+
     private static final Map<NodeKind, Supplier<? extends NodeBuilder>> CONSTRUCTOR_MAP = new HashMap<>() {{
         put(NodeKind.IF, If::new);
         put(NodeKind.RETURN, Return::new);
@@ -187,6 +192,28 @@ public abstract class NodeBuilder {
 
     public NodeBuilder flag(int flag) {
         this.flags |= flag;
+        return this;
+    }
+
+    public NodeBuilder symbolInfo(Symbol symbol) {
+        Optional<ModuleSymbol> module = symbol.getModule();
+        if (module.isEmpty()) {
+            codedata()
+                    .module(defaultModuleName)
+                    .version("0.0.0");
+            return this;
+        }
+
+        ModuleID moduleId = module.get().id();
+        String orgName = moduleId.orgName();
+        String packageName = moduleId.packageName();
+        String versionName = moduleId.version();
+
+        metadata().icon(String.format(CENTRAL_ICON_URL, orgName, packageName, versionName));
+        codedata()
+                .org(orgName)
+                .module(packageName)
+                .version(versionName);
         return this;
     }
 
@@ -425,12 +452,11 @@ public abstract class NodeBuilder {
             return this;
         }
 
-        public PropertiesBuilder<T> callExpression(ExpressionNode expressionNode, String key,
-                                                   Property propertyTemplate) {
+        public PropertiesBuilder<T> callExpression(ExpressionNode expressionNode, String key) {
             Property client = Property.Builder.getInstance()
                     .metadata()
-                        .label(propertyTemplate.metadata().label())
-                        .description(propertyTemplate.metadata().description())
+                        .label(Property.CONNECTION_LABEL)
+                        .description(Property.CONNECTION_DOC)
                         .stepOut()
                     .type(Property.ValueType.EXPRESSION)
                     .value(expressionNode.toString())

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -98,6 +98,8 @@ public record Property(Metadata metadata, String valueType, Object valueTypeCons
     public static final String LOCAL_SCOPE = "Local";
 
     public static final String CONNECTION_KEY = "connection";
+    public static final String CONNECTION_LABEL = "Connection";
+    public static final String CONNECTION_DOC = "Connection to use";
 
     public static final String COMMENT_LABEL = "Comment";
     public static final String COMMENT_KEY = "comment";

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get1.json
@@ -895,6 +895,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get1.json
@@ -39,8 +39,8 @@
         "id": "45951",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -48,6 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -86,7 +87,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/apples\"",
@@ -96,7 +97,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -119,8 +120,8 @@
         "id": "46936",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -128,6 +129,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -156,7 +158,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/apples\"",
@@ -166,7 +168,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -179,8 +181,8 @@
         "id": "47942",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -188,6 +190,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -216,7 +219,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/apples\"",
@@ -226,7 +229,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "value": "()",
@@ -240,8 +243,8 @@
         "id": "48916",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -249,6 +252,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -287,10 +291,19 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -310,8 +323,8 @@
         "id": "49900",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -319,6 +332,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -357,10 +371,19 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -380,8 +403,8 @@
         "id": "50886",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -389,6 +412,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -427,10 +451,19 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -450,8 +483,8 @@
         "id": "51900",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -459,6 +492,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -497,10 +531,19 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -520,8 +563,8 @@
         "id": "52876",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -529,6 +572,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -567,10 +611,19 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -590,8 +643,8 @@
         "id": "53920",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -599,6 +652,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -637,11 +691,20 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "value": "{\n            \"first-header\": \"first\",\n            \"second-header\": \"second\"\n        }",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -661,8 +724,8 @@
         "id": "57836",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -670,6 +733,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -708,10 +772,19 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -731,8 +804,8 @@
         "id": "58846",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -740,6 +813,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -778,10 +852,19 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -803,7 +886,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -839,7 +923,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -849,7 +933,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get2.json
@@ -212,6 +212,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get2.json
@@ -39,8 +39,8 @@
         "id": "62796",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -48,6 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -86,7 +87,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/pears\"",
@@ -96,7 +97,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -119,8 +120,8 @@
         "id": "63799",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -128,6 +129,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -166,7 +168,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/pears\"",
@@ -176,7 +178,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -201,7 +203,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -237,7 +240,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -247,7 +250,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get3.json
@@ -39,8 +39,8 @@
         "id": "67747",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -48,6 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -76,7 +77,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/bananas\"",
@@ -86,7 +87,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -101,7 +102,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -137,7 +139,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -147,7 +149,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get3.json
@@ -111,6 +111,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get4.json
@@ -167,6 +167,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-get4.json
@@ -95,8 +95,8 @@
         "id": "72710",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -104,6 +104,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -132,7 +133,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/milkshake\"",
@@ -142,7 +143,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -157,7 +158,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -193,7 +195,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -203,7 +205,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post1.json
@@ -39,8 +39,8 @@
         "id": "45965",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -48,6 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -86,7 +87,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Resource path\n"
+              "description": "Resource path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/apples\"",
@@ -96,7 +97,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"red apple\"",
@@ -106,7 +107,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -115,7 +116,7 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -138,8 +139,8 @@
         "id": "46962",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -147,6 +148,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -175,7 +177,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Resource path\n"
+              "description": "Resource path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/apples\"",
@@ -185,7 +187,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"green apple\"",
@@ -195,7 +197,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -204,7 +206,7 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -217,8 +219,8 @@
         "id": "47944",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -226,6 +228,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -264,7 +267,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"western red apple\"",
@@ -274,7 +277,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -283,10 +286,19 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -306,8 +318,8 @@
         "id": "48962",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -315,6 +327,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -353,7 +366,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "{\"type\": \"red apple\"}",
@@ -363,7 +376,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -372,11 +385,20 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "value": "\"application/json\"",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -396,8 +418,8 @@
         "id": "49908",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -405,6 +427,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -443,7 +466,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"green apple\"",
@@ -453,7 +476,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -462,10 +485,19 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -485,8 +517,8 @@
         "id": "50924",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -494,6 +526,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -532,7 +565,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"green apple\"",
@@ -542,7 +575,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -551,10 +584,19 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -574,8 +616,8 @@
         "id": "51936",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -583,6 +625,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -621,7 +664,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"red apple\"",
@@ -631,7 +674,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "value": "{\n            \"first-header\": \"first\",\n            \"second-header\": \"second\"\n        }",
@@ -641,10 +684,19 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -664,8 +716,8 @@
         "id": "55864",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -673,6 +725,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -711,7 +764,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"red apple\"",
@@ -721,7 +774,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -730,10 +783,19 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -753,8 +815,8 @@
         "id": "56876",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -762,6 +824,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -800,7 +863,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"green apple\"",
@@ -810,7 +873,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -819,10 +882,19 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -844,7 +916,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -880,7 +953,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -890,7 +963,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post1.json
@@ -925,6 +925,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post2.json
@@ -249,6 +249,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post2.json
@@ -39,8 +39,8 @@
         "id": "60821",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -48,6 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -86,7 +87,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Resource path\n"
+              "description": "Resource path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/pears\"",
@@ -96,7 +97,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"pear\"",
@@ -106,7 +107,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -115,7 +116,7 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -138,8 +139,8 @@
         "id": "61821",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -147,6 +148,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -185,7 +187,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"pear\"",
@@ -195,7 +197,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -204,10 +206,19 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
+            "editable": true
+          },
+          "params": {
+            "metadata": {
+              "label": "params",
+              "description": "The query parameters"
+            },
+            "valueType": "EXPRESSION",
+            "optional": false,
             "editable": true
           },
           "type": {
@@ -229,7 +240,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -265,7 +277,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -275,7 +287,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post3.json
@@ -39,8 +39,8 @@
         "id": "65774",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -48,6 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -76,7 +77,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Resource path\n"
+              "description": "Resource path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/bananas\"",
@@ -86,7 +87,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"banana\"",
@@ -96,7 +97,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -105,7 +106,7 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -120,7 +121,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -156,7 +158,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -166,7 +168,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post3.json
@@ -130,6 +130,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post4.json
@@ -186,6 +186,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/action_call-http-post4.json
@@ -95,8 +95,8 @@
         "id": "70742",
         "metadata": {
           "label": "post",
-          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -104,6 +104,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -132,7 +133,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Resource path\n"
+              "description": "Resource path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/milkshake\"",
@@ -142,7 +143,7 @@
           "message": {
             "metadata": {
               "label": "message",
-              "description": "An HTTP outbound request or any allowed payload\n"
+              "description": "An HTTP outbound request or any allowed payload"
             },
             "valueType": "EXPRESSION",
             "value": "\"mixed fruit\"",
@@ -152,7 +153,7 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -161,7 +162,7 @@
           "mediaType": {
             "metadata": {
               "label": "mediaType",
-              "description": "The MIME type header of the request entity\n"
+              "description": "The MIME type header of the request entity"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -176,7 +177,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -212,7 +214,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -222,7 +224,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -119,11 +119,17 @@
       {
         "id": "46777",
         "metadata": {
-          "label": "Custom Expression",
-          "description": "Represents a custom Ballerina expression"
+          "label": "myRemoteFn",
+          "description": "",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/$anon_._0.0.0.png"
         },
         "codedata": {
-          "node": "EXPRESSION",
+          "node": "ACTION_CALL",
+          "org": "$anon",
+          "module": ".",
+          "object": "Client",
+          "symbol": "myRemoteFn",
+          "version": "0.0.0",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -139,13 +145,13 @@
         },
         "returning": false,
         "properties": {
-          "statement": {
+          "connection": {
             "metadata": {
-              "label": "Statement",
-              "description": "Ballerina statement"
+              "label": "Connection",
+              "description": "Connection to use"
             },
             "valueType": "EXPRESSION",
-            "value": "myModuleCl->myRemoteFn()",
+            "value": "    myModuleCl",
             "optional": false,
             "editable": true
           }
@@ -348,11 +354,17 @@
       {
         "id": "51736",
         "metadata": {
-          "label": "Custom Expression",
-          "description": "Represents a custom Ballerina expression"
+          "label": "myRemoteFn",
+          "description": "",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/$anon_._0.0.0.png"
         },
         "codedata": {
-          "node": "EXPRESSION",
+          "node": "ACTION_CALL",
+          "org": "$anon",
+          "module": ".",
+          "object": "Client",
+          "symbol": "myRemoteFn",
+          "version": "0.0.0",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -368,13 +380,13 @@
         },
         "returning": false,
         "properties": {
-          "statement": {
+          "connection": {
             "metadata": {
-              "label": "Statement",
-              "description": "Ballerina statement"
+              "label": "Connection",
+              "description": "Connection to use"
             },
             "valueType": "EXPRESSION",
-            "value": "myLocalCl->myRemoteFn()",
+            "value": "    myLocalCl",
             "optional": false,
             "editable": true
           }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -444,6 +444,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -103,15 +103,6 @@
             "optional": true,
             "editable": true
           },
-          "targetType": {
-            "metadata": {
-              "label": "targetType",
-              "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
-            },
-            "valueType": "EXPRESSION",
-            "optional": true,
-            "editable": true
-          },
           "type": {
             "metadata": {
               "label": "Variable Type",
@@ -280,15 +271,6 @@
             "metadata": {
               "label": "headers",
               "description": "The entity headers"
-            },
-            "valueType": "EXPRESSION",
-            "optional": true,
-            "editable": true
-          },
-          "targetType": {
-            "metadata": {
-              "label": "targetType",
-              "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -478,7 +460,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "Target service url"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -487,7 +469,8 @@
           },
           "config": {
             "metadata": {
-              "label": "config"
+              "label": "config",
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -519,16 +502,11 @@
       {
         "id": "41709",
         "metadata": {
-          "label": "New Connection",
-          "description": "",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/$anon_._0.0.0.png"
+          "label": "Variable",
+          "description": "Assign a value to a variable"
         },
         "codedata": {
-          "node": "NEW_CONNECTION",
-          "org": "$anon",
-          "module": ".",
-          "object": "Client",
-          "symbol": "init",
+          "node": "VARIABLE",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -544,19 +522,19 @@
         },
         "returning": false,
         "properties": {
-          "scope": {
+          "expression": {
             "metadata": {
-              "label": "Connection Scope",
-              "description": "Scope of the connection, Global or Local"
+              "label": "Expression",
+              "description": "Expression"
             },
-            "valueType": "ENUM",
-            "value": "Global",
+            "valueType": "EXPRESSION",
+            "value": "new MyClient()",
             "optional": false,
             "editable": true
           },
           "variable": {
             "metadata": {
-              "label": "Variable Name",
+              "label": "Name",
               "description": "Name of the variable"
             },
             "valueType": "IDENTIFIER",
@@ -566,7 +544,7 @@
           },
           "type": {
             "metadata": {
-              "label": "Variable Type",
+              "label": "Type",
               "description": "Type of the variable"
             },
             "valueType": "TYPE",
@@ -580,16 +558,11 @@
       {
         "id": "40698",
         "metadata": {
-          "label": "New Connection",
-          "description": "",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/$anon_._0.0.0.png"
+          "label": "Variable",
+          "description": "Assign a value to a variable"
         },
         "codedata": {
-          "node": "NEW_CONNECTION",
-          "org": "$anon",
-          "module": ".",
-          "object": "Client",
-          "symbol": "init",
+          "node": "VARIABLE",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -605,19 +578,19 @@
         },
         "returning": false,
         "properties": {
-          "scope": {
+          "expression": {
             "metadata": {
-              "label": "Connection Scope",
-              "description": "Scope of the connection, Global or Local"
+              "label": "Expression",
+              "description": "Expression"
             },
-            "valueType": "ENUM",
-            "value": "Global",
+            "valueType": "EXPRESSION",
+            "value": "new",
             "optional": false,
             "editable": true
           },
           "variable": {
             "metadata": {
-              "label": "Variable Name",
+              "label": "Name",
               "description": "Name of the variable"
             },
             "valueType": "IDENTIFIER",
@@ -627,7 +600,7 @@
           },
           "type": {
             "metadata": {
-              "label": "Variable Type",
+              "label": "Type",
               "description": "Type of the variable"
             },
             "valueType": "TYPE",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -39,8 +39,8 @@
         "id": "45807",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -48,6 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -86,7 +87,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/hello\"",
@@ -96,7 +97,16 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
+            },
+            "valueType": "EXPRESSION",
+            "optional": true,
+            "editable": true
+          },
+          "targetType": {
+            "metadata": {
+              "label": "targetType",
+              "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -211,8 +221,8 @@
         "id": "49773",
         "metadata": {
           "label": "get",
-          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "ACTION_CALL",
@@ -220,6 +230,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -258,7 +269,7 @@
           "path": {
             "metadata": {
               "label": "path",
-              "description": "Request path\n"
+              "description": "Request path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/hello\"",
@@ -268,7 +279,16 @@
           "headers": {
             "metadata": {
               "label": "headers",
-              "description": "The entity headers\n"
+              "description": "The entity headers"
+            },
+            "valueType": "EXPRESSION",
+            "optional": true,
+            "editable": true
+          },
+          "targetType": {
+            "metadata": {
+              "label": "targetType",
+              "description": "HTTP response, `anydata` or stream of HTTP SSE, which is expected to be returned after data binding"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -421,7 +441,8 @@
         "id": "39739",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -457,7 +478,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "Target service url"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -466,8 +487,7 @@
           },
           "config": {
             "metadata": {
-              "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "label": "config"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -499,11 +519,16 @@
       {
         "id": "41709",
         "metadata": {
-          "label": "Custom Expression",
-          "description": "Represents a custom Ballerina expression"
+          "label": "New Connection",
+          "description": "",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/$anon_._0.0.0.png"
         },
         "codedata": {
-          "node": "EXPRESSION",
+          "node": "NEW_CONNECTION",
+          "org": "$anon",
+          "module": ".",
+          "object": "Client",
+          "symbol": "init",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -519,13 +544,13 @@
         },
         "returning": false,
         "properties": {
-          "statement": {
+          "scope": {
             "metadata": {
-              "label": "Statement",
-              "description": "Ballerina statement"
+              "label": "Connection Scope",
+              "description": "Scope of the connection, Global or Local"
             },
-            "valueType": "EXPRESSION",
-            "value": "new MyClient()",
+            "valueType": "ENUM",
+            "value": "Global",
             "optional": false,
             "editable": true
           },
@@ -555,11 +580,16 @@
       {
         "id": "40698",
         "metadata": {
-          "label": "Custom Expression",
-          "description": "Represents a custom Ballerina expression"
+          "label": "New Connection",
+          "description": "",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/$anon_._0.0.0.png"
         },
         "codedata": {
-          "node": "EXPRESSION",
+          "node": "NEW_CONNECTION",
+          "org": "$anon",
+          "module": ".",
+          "object": "Client",
+          "symbol": "init",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -575,13 +605,13 @@
         },
         "returning": false,
         "properties": {
-          "statement": {
+          "scope": {
             "metadata": {
-              "label": "Statement",
-              "description": "Ballerina statement"
+              "label": "Connection Scope",
+              "description": "Scope of the connection, Global or Local"
             },
-            "valueType": "EXPRESSION",
-            "value": "new",
+            "valueType": "ENUM",
+            "value": "Global",
             "optional": false,
             "editable": true
           },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
@@ -610,7 +610,8 @@
         "id": "33781",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -646,7 +647,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -656,7 +657,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
@@ -619,6 +619,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "main.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
@@ -138,8 +138,8 @@
                 "id": "40117",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -147,6 +147,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -185,7 +186,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/western/apples\"",
@@ -195,7 +196,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -339,7 +340,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -375,7 +377,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -385,7 +387,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
@@ -349,6 +349,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "error_handler.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
@@ -611,6 +611,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "error_handler.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
@@ -138,8 +138,8 @@
                 "id": "50038",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -147,6 +147,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -185,7 +186,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/western/oranges\"",
@@ -195,7 +196,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -375,8 +376,8 @@
                         "id": "55159",
                         "metadata": {
                           "label": "post",
-                          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                         },
                         "codedata": {
                           "node": "ACTION_CALL",
@@ -384,6 +385,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "post",
+                          "version": "2.12.1",
                           "lineRange": {
                             "fileName": "error_handler.bal",
                             "startLine": {
@@ -422,7 +424,7 @@
                           "path": {
                             "metadata": {
                               "label": "path",
-                              "description": "Resource path\n"
+                              "description": "Resource path"
                             },
                             "valueType": "EXPRESSION",
                             "value": "\"/log\"",
@@ -432,7 +434,7 @@
                           "message": {
                             "metadata": {
                               "label": "message",
-                              "description": "An HTTP outbound request or any allowed payload\n"
+                              "description": "An HTTP outbound request or any allowed payload"
                             },
                             "valueType": "EXPRESSION",
                             "value": "\"Error occurred while getting the response\"",
@@ -442,7 +444,7 @@
                           "headers": {
                             "metadata": {
                               "label": "headers",
-                              "description": "The entity headers\n"
+                              "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
                             "optional": true,
@@ -451,7 +453,7 @@
                           "mediaType": {
                             "metadata": {
                               "label": "mediaType",
-                              "description": "The MIME type header of the request entity\n"
+                              "description": "The MIME type header of the request entity"
                             },
                             "valueType": "EXPRESSION",
                             "optional": true,
@@ -600,7 +602,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -636,7 +639,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -646,7 +649,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
@@ -305,6 +305,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "error_handler.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
@@ -82,8 +82,8 @@
                 "id": "64920",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -91,6 +91,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -129,7 +130,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/western/pineapples\"",
@@ -139,7 +140,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -295,7 +296,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -331,7 +333,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -341,7 +343,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -226,6 +226,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -46,7 +46,6 @@
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "data.jsondata",
-          "object": "data.jsondata",
           "symbol": "toJson",
           "version": "0.2.0",
           "lineRange": {
@@ -108,7 +107,6 @@
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "data.jsondata",
-          "object": "data.jsondata",
           "symbol": "parseAsType",
           "version": "0.2.0",
           "lineRange": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -39,14 +39,16 @@
         "id": "53873",
         "metadata": {
           "label": "toJson",
-          "description": "Converts a value of type `anydata` to `json`.\n\n",
-          "icon": ""
+          "description": "Converts a value of type `anydata` to `json`.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_data.jsondata_0.2.0.png"
         },
         "codedata": {
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "data.jsondata",
+          "object": "data.jsondata",
           "symbol": "toJson",
+          "version": "0.2.0",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
@@ -65,7 +67,7 @@
           "v": {
             "metadata": {
               "label": "v",
-              "description": "Source anydata value\n"
+              "description": "Source anydata value"
             },
             "valueType": "EXPRESSION",
             "value": "payload",
@@ -99,14 +101,16 @@
         "id": "54869",
         "metadata": {
           "label": "parseAsType",
-          "description": "Convert value of type `json` to subtype of `anydata`.\n\n",
-          "icon": ""
+          "description": "Convert value of type `json` to subtype of `anydata`.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_data.jsondata_0.2.0.png"
         },
         "codedata": {
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "data.jsondata",
+          "object": "data.jsondata",
           "symbol": "parseAsType",
+          "version": "0.2.0",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
@@ -125,7 +129,7 @@
           "v": {
             "metadata": {
               "label": "v",
-              "description": "Source JSON value\n"
+              "description": "Source JSON value"
             },
             "valueType": "EXPRESSION",
             "value": "jsonResult",
@@ -135,7 +139,16 @@
           "options": {
             "metadata": {
               "label": "options",
-              "description": "Options to be used for filtering in the projection\n"
+              "description": "Options to be used for filtering in the projection"
+            },
+            "valueType": "EXPRESSION",
+            "optional": true,
+            "editable": true
+          },
+          "t": {
+            "metadata": {
+              "label": "t",
+              "description": "Target type"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -206,7 +219,8 @@
         "id": "36771",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -242,7 +256,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -252,7 +266,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -226,6 +226,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -46,7 +46,6 @@
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "data.jsondata",
-          "object": "data.jsondata",
           "symbol": "toJson",
           "version": "0.2.0",
           "lineRange": {
@@ -108,7 +107,6 @@
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "data.jsondata",
-          "object": "data.jsondata",
           "symbol": "parseAsType",
           "version": "0.2.0",
           "lineRange": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -39,14 +39,16 @@
         "id": "53873",
         "metadata": {
           "label": "toJson",
-          "description": "Converts a value of type `anydata` to `json`.\n\n",
-          "icon": ""
+          "description": "Converts a value of type `anydata` to `json`.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_data.jsondata_0.2.0.png"
         },
         "codedata": {
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "data.jsondata",
+          "object": "data.jsondata",
           "symbol": "toJson",
+          "version": "0.2.0",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
@@ -65,7 +67,7 @@
           "v": {
             "metadata": {
               "label": "v",
-              "description": "Source anydata value\n"
+              "description": "Source anydata value"
             },
             "valueType": "EXPRESSION",
             "value": "payload",
@@ -99,14 +101,16 @@
         "id": "54869",
         "metadata": {
           "label": "parseAsType",
-          "description": "Convert value of type `json` to subtype of `anydata`.\n\n",
-          "icon": ""
+          "description": "Convert value of type `json` to subtype of `anydata`.\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_data.jsondata_0.2.0.png"
         },
         "codedata": {
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "data.jsondata",
+          "object": "data.jsondata",
           "symbol": "parseAsType",
+          "version": "0.2.0",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
@@ -125,7 +129,7 @@
           "v": {
             "metadata": {
               "label": "v",
-              "description": "Source JSON value\n"
+              "description": "Source JSON value"
             },
             "valueType": "EXPRESSION",
             "value": "jsonResult",
@@ -135,7 +139,16 @@
           "options": {
             "metadata": {
               "label": "options",
-              "description": "Options to be used for filtering in the projection\n"
+              "description": "Options to be used for filtering in the projection"
+            },
+            "valueType": "EXPRESSION",
+            "optional": true,
+            "editable": true
+          },
+          "t": {
+            "metadata": {
+              "label": "t",
+              "description": "Target type"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -206,7 +219,8 @@
         "id": "36771",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -242,7 +256,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -252,7 +266,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
@@ -13,17 +13,17 @@
     "fileName": "function_call.bal",
     "nodes": [
       {
-        "id": "40150",
+        "id": "41390",
         "metadata": {
-          "label": "HTTP API"
+          "label": "Start"
         },
         "codedata": {
-          "node": "EVENT_HTTP_API",
+          "node": "EVENT_START",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
               "line": 8,
-              "offset": 4
+              "offset": 44
             },
             "endLine": {
               "line": 19,
@@ -33,29 +33,7 @@
           "sourceCode": "resource function get apples(int count) {\n        if count > 20 {\n            log:printWarn(\"Count is greater than 20\");\n        }\n        log:printInfo(\"Getting apples\");\n        json|error res = foodClient->get(\"/western/apples?count=\" + count.toString());\n        if res is error {\n            log:printError(\"Failed to get the response\");\n        } else {\n            log:printInfo(\"Response: \", response = res);\n        }\n    }"
         },
         "returning": false,
-        "properties": {
-          "method": {
-            "metadata": {
-              "label": "Method",
-              "description": "HTTP Method"
-            },
-            "valueType": "IDENTIFIER",
-            "value": "get",
-            "optional": false,
-            "editable": true
-          },
-          "path": {
-            "metadata": {
-              "label": "Path",
-              "description": "HTTP Path"
-            },
-            "valueType": "STRING",
-            "value": "apples",
-            "optional": false,
-            "editable": true
-          }
-        },
-        "flags": 2048
+        "flags": 0
       },
       {
         "id": "40991",
@@ -116,14 +94,16 @@
                 "id": "42090",
                 "metadata": {
                   "label": "printWarn",
-                  "description": "Prints warn logs.\n```ballerina\nlog:printWarn(\"warn message\", id = 845315)\n```\n\n",
+                  "description": "Prints warn logs.\n```ballerina\nlog:printWarn(\"warn message\", id = 845315)\n```\n",
                   "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_log_2.10.0.png"
                 },
                 "codedata": {
                   "node": "FUNCTION_CALL",
                   "org": "ballerina",
                   "module": "log",
+                  "object": "log",
                   "symbol": "printWarn",
+                  "version": "2.10.0",
                   "lineRange": {
                     "fileName": "function_call.bal",
                     "startLine": {
@@ -142,17 +122,25 @@
                   "msg": {
                     "metadata": {
                       "label": "msg",
-                      "description": "The message to be logged\n"
+                      "description": "The message to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"Count is greater than 20\"",
                     "optional": false,
                     "editable": true
                   },
+                  "error": {
+                    "metadata": {
+                      "label": "error"
+                    },
+                    "valueType": "EXPRESSION",
+                    "optional": true,
+                    "editable": true
+                  },
                   "stackTrace": {
                     "metadata": {
                       "label": "stackTrace",
-                      "description": "The error stack trace to be logged\n"
+                      "description": "The error stack trace to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -161,7 +149,7 @@
                   "keyValues": {
                     "metadata": {
                       "label": "keyValues",
-                      "description": "The key-value pairs to be logged\n"
+                      "description": "The key-value pairs to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "optional": false,
@@ -179,14 +167,16 @@
         "id": "43936",
         "metadata": {
           "label": "printInfo",
-          "description": "Prints info logs.\n```ballerina\nlog:printInfo(\"info message\", id = 845315)\n```\n\n",
+          "description": "Prints info logs.\n```ballerina\nlog:printInfo(\"info message\", id = 845315)\n```\n",
           "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_log_2.10.0.png"
         },
         "codedata": {
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "log",
+          "object": "log",
           "symbol": "printInfo",
+          "version": "2.10.0",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
@@ -205,17 +195,25 @@
           "msg": {
             "metadata": {
               "label": "msg",
-              "description": "The message to be logged\n"
+              "description": "The message to be logged"
             },
             "valueType": "EXPRESSION",
             "value": "\"Getting apples\"",
             "optional": false,
             "editable": true
           },
+          "error": {
+            "metadata": {
+              "label": "error"
+            },
+            "valueType": "EXPRESSION",
+            "optional": true,
+            "editable": true
+          },
           "stackTrace": {
             "metadata": {
               "label": "stackTrace",
-              "description": "The error stack trace to be logged\n"
+              "description": "The error stack trace to be logged"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -224,7 +222,7 @@
           "keyValues": {
             "metadata": {
               "label": "keyValues",
-              "description": "The key-value pairs to be logged\n"
+              "description": "The key-value pairs to be logged"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -273,7 +271,7 @@
           },
           "variable": {
             "metadata": {
-              "label": "Data variable",
+              "label": "Variable Name",
               "description": "Name of the variable"
             },
             "valueType": "IDENTIFIER",
@@ -283,8 +281,7 @@
           },
           "path": {
             "metadata": {
-              "label": "path",
-              "description": "Request path\n"
+              "label": "path"
             },
             "valueType": "EXPRESSION",
             "value": "\"/western/apples?count=\" + count.toString()",
@@ -293,8 +290,15 @@
           },
           "headers": {
             "metadata": {
-              "label": "headers",
-              "description": "The entity headers\n"
+              "label": "headers"
+            },
+            "valueType": "EXPRESSION",
+            "optional": true,
+            "editable": true
+          },
+          "targetType": {
+            "metadata": {
+              "label": "targetType"
             },
             "valueType": "EXPRESSION",
             "optional": true,
@@ -302,7 +306,7 @@
           },
           "type": {
             "metadata": {
-              "label": "Data type",
+              "label": "Variable Type",
               "description": "Type of the variable"
             },
             "valueType": "TYPE",
@@ -372,14 +376,16 @@
                 "id": "47053",
                 "metadata": {
                   "label": "printError",
-                  "description": "Prints error logs.\n```ballerina\nerror e = error(\"error occurred\");\nlog:printError(\"error log with cause\", 'error = e, id = 845315);\n```\n\n",
+                  "description": "Prints error logs.\n```ballerina\nerror e = error(\"error occurred\");\nlog:printError(\"error log with cause\", 'error = e, id = 845315);\n```\n",
                   "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_log_2.10.0.png"
                 },
                 "codedata": {
                   "node": "FUNCTION_CALL",
                   "org": "ballerina",
                   "module": "log",
+                  "object": "log",
                   "symbol": "printError",
+                  "version": "2.10.0",
                   "lineRange": {
                     "fileName": "function_call.bal",
                     "startLine": {
@@ -398,17 +404,25 @@
                   "msg": {
                     "metadata": {
                       "label": "msg",
-                      "description": "The message to be logged\n"
+                      "description": "The message to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"Failed to get the response\"",
                     "optional": false,
                     "editable": true
                   },
+                  "error": {
+                    "metadata": {
+                      "label": "error"
+                    },
+                    "valueType": "EXPRESSION",
+                    "optional": true,
+                    "editable": true
+                  },
                   "stackTrace": {
                     "metadata": {
                       "label": "stackTrace",
-                      "description": "The error stack trace to be logged\n"
+                      "description": "The error stack trace to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -417,7 +431,7 @@
                   "keyValues": {
                     "metadata": {
                       "label": "keyValues",
-                      "description": "The key-value pairs to be logged\n"
+                      "description": "The key-value pairs to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "optional": false,
@@ -452,14 +466,16 @@
                 "id": "49036",
                 "metadata": {
                   "label": "printInfo",
-                  "description": "Prints info logs.\n```ballerina\nlog:printInfo(\"info message\", id = 845315)\n```\n\n",
+                  "description": "Prints info logs.\n```ballerina\nlog:printInfo(\"info message\", id = 845315)\n```\n",
                   "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_log_2.10.0.png"
                 },
                 "codedata": {
                   "node": "FUNCTION_CALL",
                   "org": "ballerina",
                   "module": "log",
+                  "object": "log",
                   "symbol": "printInfo",
+                  "version": "2.10.0",
                   "lineRange": {
                     "fileName": "function_call.bal",
                     "startLine": {
@@ -478,17 +494,25 @@
                   "msg": {
                     "metadata": {
                       "label": "msg",
-                      "description": "The message to be logged\n"
+                      "description": "The message to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"Response: \"",
                     "optional": false,
                     "editable": true
                   },
+                  "error": {
+                    "metadata": {
+                      "label": "error"
+                    },
+                    "valueType": "EXPRESSION",
+                    "optional": true,
+                    "editable": true
+                  },
                   "stackTrace": {
                     "metadata": {
                       "label": "stackTrace",
-                      "description": "The error stack trace to be logged\n"
+                      "description": "The error stack trace to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -497,7 +521,7 @@
                   "keyValues": {
                     "metadata": {
                       "label": "keyValues",
-                      "description": "The key-value pairs to be logged\n"
+                      "description": "The key-value pairs to be logged"
                     },
                     "valueType": "EXPRESSION",
                     "optional": false,
@@ -552,8 +576,7 @@
           },
           "url": {
             "metadata": {
-              "label": "url",
-              "description": "URL of the target service\n"
+              "label": "url"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -562,8 +585,7 @@
           },
           "config": {
             "metadata": {
-              "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "label": "config"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -571,7 +593,7 @@
           },
           "variable": {
             "metadata": {
-              "label": "Data variable",
+              "label": "Variable Name",
               "description": "Name of the variable"
             },
             "valueType": "IDENTIFIER",
@@ -581,7 +603,7 @@
           },
           "type": {
             "metadata": {
-              "label": "Data type",
+              "label": "Variable Type",
               "description": "Type of the variable"
             },
             "valueType": "TYPE",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
@@ -290,12 +290,14 @@
         "id": "102361",
         "metadata": {
           "label": "println",
-          "description": "Prints `any`, `error` or string templates(such as `The respective int value is ${val}`) value(s) to the STDOUT\nfollowed by a new line.\n```ballerina\nio:println(\"Start processing the CSV file from \", srcFileName);\n```\n\n"
+          "description": "Prints `any`, `error` or string templates(such as `The respective int value is ${val}`) value(s) to the STDOUT\nfollowed by a new line.\n```ballerina\nio:println(\"Start processing the CSV file from \", srcFileName);\n```\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_io_1.6.1.png"
         },
         "codedata": {
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "io",
+          "object": "io",
           "symbol": "println",
           "version": "1.6.1",
           "lineRange": {
@@ -484,12 +486,14 @@
         "id": "108287",
         "metadata": {
           "label": "println",
-          "description": "Prints `any`, `error` or string templates(such as `The respective int value is ${val}`) value(s) to the STDOUT\nfollowed by a new line.\n```ballerina\nio:println(\"Start processing the CSV file from \", srcFileName);\n```\n\n"
+          "description": "Prints `any`, `error` or string templates(such as `The respective int value is ${val}`) value(s) to the STDOUT\nfollowed by a new line.\n```ballerina\nio:println(\"Start processing the CSV file from \", srcFileName);\n```\n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_io_1.6.1.png"
         },
         "codedata": {
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "io",
+          "object": "io",
           "symbol": "println",
           "version": "1.6.1",
           "lineRange": {
@@ -564,7 +568,8 @@
         "id": "36771",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -600,7 +605,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -610,7 +615,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
@@ -575,6 +575,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
@@ -297,7 +297,6 @@
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "io",
-          "object": "io",
           "symbol": "println",
           "version": "1.6.1",
           "lineRange": {
@@ -493,7 +492,6 @@
           "node": "FUNCTION_CALL",
           "org": "ballerina",
           "module": "io",
-          "object": "io",
           "symbol": "println",
           "version": "1.6.1",
           "lineRange": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
@@ -291,7 +291,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -327,7 +328,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -337,7 +338,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
@@ -300,6 +300,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
@@ -335,7 +335,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -371,7 +372,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -381,7 +382,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
@@ -344,6 +344,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
@@ -412,6 +412,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
@@ -403,7 +403,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -439,7 +440,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -449,7 +450,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -576,6 +576,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -567,7 +567,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -603,7 +604,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -613,7 +614,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
@@ -491,7 +491,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -527,7 +528,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -537,7 +538,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
@@ -500,6 +500,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
@@ -274,6 +274,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
@@ -265,7 +265,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -301,7 +302,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -311,7 +312,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
@@ -243,7 +243,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -279,7 +280,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -289,7 +290,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
@@ -252,6 +252,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
@@ -383,7 +383,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -419,7 +420,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -429,7 +430,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
@@ -392,6 +392,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
@@ -453,7 +453,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -489,7 +490,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -499,7 +500,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
@@ -462,6 +462,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
@@ -313,7 +313,8 @@
         "id": "33773",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -349,7 +350,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"/food\"",
@@ -359,7 +360,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
@@ -322,6 +322,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
@@ -30,7 +30,7 @@
               "offset": 5
             }
           },
-          "sourceCode": "resource function get cherries(map<anydata> data) returns string|error {\n        match data {\n            var obj if obj is record {|int quantity; string 'type;|} => {\n                int quantity = check int:fromString(obj.quantity.toString());\n                string 'type = obj.'type;\n                return string `Order for ${quantity} ${'type} cherries placed`;\n            }\n            _ => {\n                return error(\"Invalid data format\");\n            }\n        } on fail var e {\n            if e is error {\n                return error(\"Data processing failed\", e);\n            }\n        }\n    }"
+          "sourceCode": "resource function get cherries(map<anydata> data) returns string|error {\n        match data {\n            var obj if obj is record {|int quantity; string 'type;|} => {\n                int quantity = obj.quantity;\n                string 'type = obj.'type;\n                return string `Order for ${quantity} ${'type} cherries placed`;\n            }\n            _ => {\n                return error(\"Invalid data format\");\n            }\n        } on fail var e {\n            if e is error {\n                return error(\"Data processing failed\", e);\n            }\n        }\n    }"
         },
         "returning": false,
         "flags": 0
@@ -54,7 +54,7 @@
               "offset": 9
             }
           },
-          "sourceCode": "match data {\n            var obj if obj is record {|int quantity; string 'type;|} => {\n                int quantity = check int:fromString(obj.quantity.toString());\n                string 'type = obj.'type;\n                return string `Order for ${quantity} ${'type} cherries placed`;\n            }\n            _ => {\n                return error(\"Invalid data format\");\n            }\n        } on fail var e {\n            if e is error {\n                return error(\"Data processing failed\", e);\n            }\n        }"
+          "sourceCode": "match data {\n            var obj if obj is record {|int quantity; string 'type;|} => {\n                int quantity = obj.quantity;\n                string 'type = obj.'type;\n                return string `Order for ${quantity} ${'type} cherries placed`;\n            }\n            _ => {\n                return error(\"Invalid data format\");\n            }\n        } on fail var e {\n            if e is error {\n                return error(\"Data processing failed\", e);\n            }\n        }"
         },
         "returning": false,
         "branches": [
@@ -74,7 +74,7 @@
                   "offset": 13
                 }
               },
-              "sourceCode": "{\n                int quantity = check int:fromString(obj.quantity.toString());\n                string 'type = obj.'type;\n                return string `Order for ${quantity} ${'type} cherries placed`;\n            }"
+              "sourceCode": "{\n                int quantity = obj.quantity;\n                string 'type = obj.'type;\n                return string `Order for ${quantity} ${'type} cherries placed`;\n            }"
             },
             "repeatable": "ONE_OR_MORE",
             "properties": {
@@ -112,18 +112,13 @@
             },
             "children": [
               {
-                "id": "273373",
+                "id": "273340",
                 "metadata": {
-                  "label": "fromString",
-                  "description": "Returns the integer of a string that represents in decimal.\n\nReturns error if parameter `s` is not the decimal representation of an integer.\nThe first character may be `+` or `-`.\nThis is the inverse of function ``value:toString`` applied to an `int`.\n\n```ballerina\nint:fromString(\"76\") ⇒ 76\nint:fromString(\"-120\") ⇒ -120\nint:fromString(\"0xFFFF\") ⇒ error\n```\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_lang.int_0.0.0.png"
+                  "label": "Variable",
+                  "description": "Assign a value to a variable"
                 },
                 "codedata": {
-                  "node": "FUNCTION_CALL",
-                  "org": "ballerina",
-                  "module": "lang.int",
-                  "symbol": "fromString",
-                  "version": "0.0.0",
+                  "node": "VARIABLE",
                   "lineRange": {
                     "fileName": "match.bal",
                     "startLine": {
@@ -132,26 +127,26 @@
                     },
                     "endLine": {
                       "line": 243,
-                      "offset": 77
+                      "offset": 44
                     }
                   },
-                  "sourceCode": "int quantity = check int:fromString(obj.quantity.toString());"
+                  "sourceCode": "int quantity = obj.quantity;"
                 },
                 "returning": false,
                 "properties": {
-                  "s": {
+                  "expression": {
                     "metadata": {
-                      "label": "s",
-                      "description": "string representation of a integer value"
+                      "label": "Expression",
+                      "description": "Expression"
                     },
                     "valueType": "EXPRESSION",
-                    "value": "obj.quantity.toString()",
+                    "value": "obj.quantity",
                     "optional": false,
                     "editable": true
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Variable Name",
+                      "label": "Name",
                       "description": "Name of the variable"
                     },
                     "valueType": "IDENTIFIER",
@@ -161,7 +156,7 @@
                   },
                   "type": {
                     "metadata": {
-                      "label": "Variable Type",
+                      "label": "Type",
                       "description": "Type of the variable"
                     },
                     "valueType": "TYPE",
@@ -170,7 +165,7 @@
                     "editable": true
                   }
                 },
-                "flags": 1
+                "flags": 0
               },
               {
                 "id": "274329",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
@@ -114,11 +114,17 @@
               {
                 "id": "273373",
                 "metadata": {
-                  "label": "Custom Expression",
-                  "description": "Represents a custom Ballerina expression"
+                  "label": "fromString",
+                  "description": "Returns the integer of a string that represents in decimal.\n\nReturns error if parameter `s` is not the decimal representation of an integer.\nThe first character may be `+` or `-`.\nThis is the inverse of function ``value:toString`` applied to an `int`.\n\n```ballerina\nint:fromString(\"76\") ⇒ 76\nint:fromString(\"-120\") ⇒ -120\nint:fromString(\"0xFFFF\") ⇒ error\n```\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_lang.int_0.0.0.png"
                 },
                 "codedata": {
-                  "node": "EXPRESSION",
+                  "node": "FUNCTION_CALL",
+                  "org": "ballerina",
+                  "module": "lang.int",
+                  "object": "lang.int",
+                  "symbol": "fromString",
+                  "version": "0.0.0",
                   "lineRange": {
                     "fileName": "match.bal",
                     "startLine": {
@@ -134,13 +140,13 @@
                 },
                 "returning": false,
                 "properties": {
-                  "statement": {
+                  "s": {
                     "metadata": {
-                      "label": "Statement",
-                      "description": "Ballerina statement"
+                      "label": "s",
+                      "description": "string representation of a integer value"
                     },
                     "valueType": "EXPRESSION",
-                    "value": "int:fromString(obj.quantity.toString())",
+                    "value": "obj.quantity.toString()",
                     "optional": false,
                     "editable": true
                   },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
@@ -122,7 +122,6 @@
                   "node": "FUNCTION_CALL",
                   "org": "ballerina",
                   "module": "lang.int",
-                  "object": "lang.int",
                   "symbol": "fromString",
                   "version": "0.0.0",
                   "lineRange": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
@@ -82,8 +82,8 @@
                 "id": "39123",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -91,6 +91,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "nested_node.bal",
                     "startLine": {
@@ -129,7 +130,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/doctors/kandy\"",
@@ -139,7 +140,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -181,7 +182,8 @@
         "id": "33790",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -217,7 +219,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -227,7 +229,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
@@ -191,6 +191,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
@@ -388,6 +388,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
@@ -137,8 +137,8 @@
                         "id": "46195",
                         "metadata": {
                           "label": "get",
-                          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                         },
                         "codedata": {
                           "node": "ACTION_CALL",
@@ -146,6 +146,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "get",
+                          "version": "2.12.1",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -184,7 +185,7 @@
                           "path": {
                             "metadata": {
                               "label": "path",
-                              "description": "Request path\n"
+                              "description": "Request path"
                             },
                             "valueType": "EXPRESSION",
                             "value": "\"/doctors/kandy\"",
@@ -194,7 +195,7 @@
                           "headers": {
                             "metadata": {
                               "label": "headers",
-                              "description": "The entity headers\n"
+                              "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
                             "optional": true,
@@ -239,8 +240,8 @@
                         "id": "48181",
                         "metadata": {
                           "label": "get",
-                          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                         },
                         "codedata": {
                           "node": "ACTION_CALL",
@@ -248,6 +249,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "get",
+                          "version": "2.12.1",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -286,7 +288,7 @@
                           "path": {
                             "metadata": {
                               "label": "path",
-                              "description": "Request path\n"
+                              "description": "Request path"
                             },
                             "valueType": "EXPRESSION",
                             "value": "\"/doctors/colombo\"",
@@ -296,7 +298,7 @@
                           "headers": {
                             "metadata": {
                               "label": "headers",
-                              "description": "The entity headers\n"
+                              "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
                             "optional": true,
@@ -377,7 +379,8 @@
         "id": "33790",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -413,7 +416,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -423,7 +426,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
@@ -109,6 +109,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
@@ -100,7 +100,8 @@
         "id": "33790",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -136,7 +137,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -146,7 +147,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
@@ -504,6 +504,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
@@ -168,8 +168,8 @@
                                 "id": "64198",
                                 "metadata": {
                                   "label": "post",
-                                  "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                                  "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                                 },
                                 "codedata": {
                                   "node": "ACTION_CALL",
@@ -177,6 +177,7 @@
                                   "module": "http",
                                   "object": "Client",
                                   "symbol": "post",
+                                  "version": "2.12.1",
                                   "lineRange": {
                                     "fileName": "nested_node.bal",
                                     "startLine": {
@@ -215,7 +216,7 @@
                                   "path": {
                                     "metadata": {
                                       "label": "path",
-                                      "description": "Resource path\n"
+                                      "description": "Resource path"
                                     },
                                     "valueType": "EXPRESSION",
                                     "value": "\"/doctors/kandy\"",
@@ -225,7 +226,7 @@
                                   "message": {
                                     "metadata": {
                                       "label": "message",
-                                      "description": "An HTTP outbound request or any allowed payload\n"
+                                      "description": "An HTTP outbound request or any allowed payload"
                                     },
                                     "valueType": "EXPRESSION",
                                     "value": "\"text\"",
@@ -235,7 +236,7 @@
                                   "headers": {
                                     "metadata": {
                                       "label": "headers",
-                                      "description": "The entity headers\n"
+                                      "description": "The entity headers"
                                     },
                                     "valueType": "EXPRESSION",
                                     "optional": true,
@@ -244,7 +245,7 @@
                                   "mediaType": {
                                     "metadata": {
                                       "label": "mediaType",
-                                      "description": "The MIME type header of the request entity\n"
+                                      "description": "The MIME type header of the request entity"
                                     },
                                     "valueType": "EXPRESSION",
                                     "optional": true,
@@ -296,8 +297,8 @@
                         "id": "67027",
                         "metadata": {
                           "label": "get",
-                          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                          "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                         },
                         "codedata": {
                           "node": "ACTION_CALL",
@@ -305,6 +306,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "get",
+                          "version": "2.12.1",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -343,7 +345,7 @@
                           "path": {
                             "metadata": {
                               "label": "path",
-                              "description": "Request path\n"
+                              "description": "Request path"
                             },
                             "valueType": "EXPRESSION",
                             "value": "\"/doctors/kandy\"",
@@ -353,7 +355,7 @@
                           "headers": {
                             "metadata": {
                               "label": "headers",
-                              "description": "The entity headers\n"
+                              "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
                             "optional": true,
@@ -393,8 +395,8 @@
                 "id": "68883",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -402,6 +404,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "nested_node.bal",
                     "startLine": {
@@ -440,7 +443,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/doctors/kandy\"",
@@ -450,7 +453,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -492,7 +495,8 @@
         "id": "33790",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -528,7 +532,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -538,7 +542,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
@@ -168,8 +168,8 @@
                                 "id": "77094",
                                 "metadata": {
                                   "label": "post",
-                                  "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                                  "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                                 },
                                 "codedata": {
                                   "node": "ACTION_CALL",
@@ -177,6 +177,7 @@
                                   "module": "http",
                                   "object": "Client",
                                   "symbol": "post",
+                                  "version": "2.12.1",
                                   "lineRange": {
                                     "fileName": "nested_node.bal",
                                     "startLine": {
@@ -215,7 +216,7 @@
                                   "path": {
                                     "metadata": {
                                       "label": "path",
-                                      "description": "Resource path\n"
+                                      "description": "Resource path"
                                     },
                                     "valueType": "EXPRESSION",
                                     "value": "\"/doctors/kandy\"",
@@ -225,7 +226,7 @@
                                   "message": {
                                     "metadata": {
                                       "label": "message",
-                                      "description": "An HTTP outbound request or any allowed payload\n"
+                                      "description": "An HTTP outbound request or any allowed payload"
                                     },
                                     "valueType": "EXPRESSION",
                                     "value": "\"text\"",
@@ -235,7 +236,7 @@
                                   "headers": {
                                     "metadata": {
                                       "label": "headers",
-                                      "description": "The entity headers\n"
+                                      "description": "The entity headers"
                                     },
                                     "valueType": "EXPRESSION",
                                     "optional": true,
@@ -244,7 +245,7 @@
                                   "mediaType": {
                                     "metadata": {
                                       "label": "mediaType",
-                                      "description": "The MIME type header of the request entity\n"
+                                      "description": "The MIME type header of the request entity"
                                     },
                                     "valueType": "EXPRESSION",
                                     "optional": true,
@@ -339,8 +340,8 @@
                                 "id": "81043",
                                 "metadata": {
                                   "label": "get",
-                                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                                 },
                                 "codedata": {
                                   "node": "ACTION_CALL",
@@ -348,6 +349,7 @@
                                   "module": "http",
                                   "object": "Client",
                                   "symbol": "get",
+                                  "version": "2.12.1",
                                   "lineRange": {
                                     "fileName": "nested_node.bal",
                                     "startLine": {
@@ -386,7 +388,7 @@
                                   "path": {
                                     "metadata": {
                                       "label": "path",
-                                      "description": "Request path\n"
+                                      "description": "Request path"
                                     },
                                     "valueType": "EXPRESSION",
                                     "value": "\"/doctors/kandy\"",
@@ -396,7 +398,7 @@
                                   "headers": {
                                     "metadata": {
                                       "label": "headers",
-                                      "description": "The entity headers\n"
+                                      "description": "The entity headers"
                                     },
                                     "valueType": "EXPRESSION",
                                     "optional": true,
@@ -472,7 +474,8 @@
         "id": "33790",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -508,7 +511,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -518,7 +521,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
@@ -483,6 +483,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
@@ -153,7 +153,8 @@
         "id": "34783",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -189,7 +190,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -199,7 +200,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -232,7 +233,8 @@
         "id": "42732",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -268,7 +270,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -278,7 +280,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -311,7 +313,8 @@
         "id": "35751",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -347,7 +350,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -380,7 +383,8 @@
         "id": "43704",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -416,7 +420,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
@@ -162,6 +162,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -242,6 +243,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -322,6 +324,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -392,6 +395,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
@@ -153,7 +153,8 @@
         "id": "34783",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -189,7 +190,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -199,7 +200,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -232,7 +233,8 @@
         "id": "42732",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -268,7 +270,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -278,7 +280,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -311,7 +313,8 @@
         "id": "35751",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -347,7 +350,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -380,7 +383,8 @@
         "id": "43704",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -416,7 +420,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
@@ -162,6 +162,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -242,6 +243,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -322,6 +324,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -392,6 +395,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
@@ -50,6 +50,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -130,6 +131,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -210,6 +212,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -280,6 +283,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -350,6 +354,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -430,6 +435,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
@@ -41,7 +41,8 @@
         "id": "34783",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -77,7 +78,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -87,7 +88,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -120,7 +121,8 @@
         "id": "42732",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -156,7 +158,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -166,7 +168,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -199,7 +201,8 @@
         "id": "35751",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -235,7 +238,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -268,7 +271,8 @@
         "id": "43704",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -304,7 +308,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -337,7 +341,8 @@
         "id": "51776",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -373,7 +378,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -383,7 +388,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -416,7 +421,8 @@
         "id": "52744",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -452,7 +458,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
@@ -366,6 +366,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "simple_flow.bal",
             "startLine": {
@@ -446,6 +447,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "simple_flow.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
@@ -94,8 +94,8 @@
                 "id": "40115",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -103,6 +103,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "simple_flow.bal",
                     "startLine": {
@@ -141,7 +142,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/doctors/kandy\"",
@@ -151,7 +152,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -232,8 +233,8 @@
                 "id": "43081",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -241,6 +242,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "simple_flow.bal",
                     "startLine": {
@@ -279,7 +281,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/doctors\"",
@@ -289,7 +291,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -355,7 +357,8 @@
         "id": "33790",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -391,7 +394,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -401,7 +404,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -434,7 +437,8 @@
         "id": "34785",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -470,7 +474,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9091\"",
@@ -480,7 +484,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -523,6 +523,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -194,8 +194,8 @@
                 "id": "41121",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -203,6 +203,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -241,7 +242,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/food/apples\"",
@@ -251,7 +252,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -513,7 +514,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -549,7 +551,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -559,7 +561,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
@@ -100,7 +100,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -136,7 +137,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -146,7 +147,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
@@ -109,6 +109,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -194,8 +194,8 @@
                 "id": "59959",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -203,6 +203,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -241,7 +242,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/food/oranges\"",
@@ -251,7 +252,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -443,7 +444,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -479,7 +481,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -489,7 +491,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -453,6 +453,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -485,6 +485,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -194,8 +194,8 @@
                 "id": "71862",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -203,6 +203,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -241,7 +242,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/food/mangos\"",
@@ -251,7 +252,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -475,7 +476,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -511,7 +513,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -521,7 +523,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
@@ -963,6 +963,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
@@ -194,8 +194,8 @@
                 "id": "83770",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -203,6 +203,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -241,7 +242,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/food/pineapples\"",
@@ -251,7 +252,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -651,8 +652,8 @@
                         "id": "93839",
                         "metadata": {
                           "label": "post",
-                          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                          "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                         },
                         "codedata": {
                           "node": "ACTION_CALL",
@@ -660,6 +661,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "post",
+                          "version": "2.12.1",
                           "lineRange": {
                             "fileName": "while.bal",
                             "startLine": {
@@ -698,7 +700,7 @@
                           "path": {
                             "metadata": {
                               "label": "path",
-                              "description": "Resource path\n"
+                              "description": "Resource path"
                             },
                             "valueType": "EXPRESSION",
                             "value": "\"/admin/restart\"",
@@ -708,7 +710,7 @@
                           "message": {
                             "metadata": {
                               "label": "message",
-                              "description": "An HTTP outbound request or any allowed payload\n"
+                              "description": "An HTTP outbound request or any allowed payload"
                             },
                             "valueType": "EXPRESSION",
                             "value": "{body: e.message()}",
@@ -718,7 +720,7 @@
                           "headers": {
                             "metadata": {
                               "label": "headers",
-                              "description": "The entity headers\n"
+                              "description": "The entity headers"
                             },
                             "valueType": "EXPRESSION",
                             "optional": true,
@@ -727,7 +729,7 @@
                           "mediaType": {
                             "metadata": {
                               "label": "mediaType",
-                              "description": "The MIME type header of the request entity\n"
+                              "description": "The MIME type header of the request entity"
                             },
                             "valueType": "EXPRESSION",
                             "optional": true,
@@ -952,7 +954,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -988,7 +991,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -998,7 +1001,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -537,6 +537,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -194,8 +194,8 @@
                 "id": "107575",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -203,6 +203,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -241,7 +242,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/food/bananas\"",
@@ -251,7 +252,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -527,7 +528,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -563,7 +565,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -573,7 +575,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -537,6 +537,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -194,8 +194,8 @@
                 "id": "122454",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -203,6 +203,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -241,7 +242,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/food/grapes\"",
@@ -251,7 +252,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -527,7 +528,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -563,7 +565,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -573,7 +575,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -621,6 +621,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -194,8 +194,8 @@
                 "id": "137339",
                 "metadata": {
                   "label": "get",
-                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.0.png"
+                  "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
                 },
                 "codedata": {
                   "node": "ACTION_CALL",
@@ -203,6 +203,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
+                  "version": "2.12.1",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -241,7 +242,7 @@
                   "path": {
                     "metadata": {
                       "label": "path",
-                      "description": "Request path\n"
+                      "description": "Request path"
                     },
                     "valueType": "EXPRESSION",
                     "value": "\"/food/watermelons\"",
@@ -251,7 +252,7 @@
                   "headers": {
                     "metadata": {
                       "label": "headers",
-                      "description": "The entity headers\n"
+                      "description": "The entity headers"
                     },
                     "valueType": "EXPRESSION",
                     "optional": true,
@@ -611,7 +612,8 @@
         "id": "33789",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -647,7 +649,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://localhost:9090\"",
@@ -657,7 +659,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/match.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/match.bal
@@ -241,7 +241,7 @@ service /market on new http:Listener(9090) {
     resource function get cherries(map<anydata> data) returns string|error {
         match data {
             var obj if obj is record {|int quantity; string 'type;|} => {
-                int quantity = check int:fromString(obj.quantity.toString());
+                int quantity = obj.quantity;
                 string 'type = obj.'type;
                 return string `Order for ${quantity} ${'type} cherries placed`;
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
@@ -18,6 +18,7 @@
           "module": "grpc",
           "object": "Client",
           "symbol": "init",
+          "version": "1.11.0",
           "lineRange": {
             "fileName": "connections.bal",
             "startLine": {
@@ -98,6 +99,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "main.bal",
             "startLine": {
@@ -178,6 +180,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "connections.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
@@ -9,7 +9,8 @@
         "id": "35776",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The base client used in the generated client code to provide the capability for initiating the contact and executing remote calls with a remote gRPC service.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_grpc_1.11.0.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -45,7 +46,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "The server URL\n"
+              "description": "The server URL"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://example.com\"",
@@ -55,7 +56,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "- The client endpoint configurations\n"
+              "description": "- The client endpoint configurations"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -88,7 +89,8 @@
         "id": "33792",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -124,7 +126,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://example.com\"",
@@ -134,7 +136,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -167,7 +169,8 @@
         "id": "34766",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -203,7 +206,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
@@ -9,7 +9,8 @@
         "id": "37760",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The base client used in the generated client code to provide the capability for initiating the contact and executing remote calls with a remote gRPC service.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_grpc_1.11.0.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -45,7 +46,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "The server URL\n"
+              "description": "The server URL"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://example.com\"",
@@ -55,7 +56,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "- The client endpoint configurations\n"
+              "description": "- The client endpoint configurations"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -88,7 +89,8 @@
         "id": "35776",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.12.1.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -124,7 +126,7 @@
           "url": {
             "metadata": {
               "label": "url",
-              "description": "URL of the target service\n"
+              "description": "URL of the target service"
             },
             "valueType": "EXPRESSION",
             "value": "\"http://example.com\"",
@@ -134,7 +136,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "The configurations to be used when initializing the `client`\n"
+              "description": "The configurations to be used when initializing the `client`"
             },
             "valueType": "EXPRESSION",
             "optional": false,
@@ -167,7 +169,8 @@
         "id": "36750",
         "metadata": {
           "label": "New Connection",
-          "description": "Create a new connection"
+          "description": "Ballerina Redis connector provides the capability to access Redis cache.\nThis connector lets you to perform operations to access and manipulate key-value data stored in a Redis database. \n",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_redis_3.0.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -203,7 +206,7 @@
           "config": {
             "metadata": {
               "label": "config",
-              "description": "configuration for the connector\n"
+              "description": "configuration for the connector"
             },
             "valueType": "EXPRESSION",
             "optional": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
@@ -18,6 +18,7 @@
           "module": "grpc",
           "object": "Client",
           "symbol": "init",
+          "version": "1.11.0",
           "lineRange": {
             "fileName": "source.bal",
             "startLine": {
@@ -98,6 +99,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
+          "version": "2.12.1",
           "lineRange": {
             "fileName": "source.bal",
             "startLine": {
@@ -178,6 +180,7 @@
           "module": "redis",
           "object": "Client",
           "symbol": "init",
+          "version": "3.0.2",
           "lineRange": {
             "fileName": "source.bal",
             "startLine": {


### PR DESCRIPTION
## Purpose
Currently, the central API is used to retrieve metadata information for nodes. With the new approach, this metadata can instead be derived directly from the Ballerina symbol.