### PR TITLE
Include the fat JAR of the LS extension

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/AvailableNodesGenerator.java
@@ -217,7 +217,7 @@ public class AvailableNodesGenerator {
     }
 
     private static List<Item> fetchConnections(ModuleID moduleId, String parentSymbol) {
-        DatabaseManager dbManager = new DatabaseManager();
+        DatabaseManager dbManager = DatabaseManager.getInstance();
         Optional<FunctionResult> connectorResult =
                 dbManager.getFunction(moduleId.orgName(), moduleId.packageName(), NewConnection.INIT_SYMBOL,
                         DatabaseManager.FunctionKind.CONNECTOR);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectorGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ConnectorGenerator.java
@@ -54,7 +54,7 @@ public class ConnectorGenerator {
         if (CommonUtils.hasNoKeyword(queryMap, "offset")) {
             modifiedQueryMap.put("offset", "0");
         }
-        DatabaseManager dbManager = new DatabaseManager();
+        DatabaseManager dbManager = DatabaseManager.getInstance();
 
         List<FunctionResult> connectorResults = CommonUtils.hasNoKeyword(queryMap, "q") ?
                 dbManager.getAllFunctions(DatabaseManager.FunctionKind.CONNECTOR) :

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/FunctionGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/FunctionGenerator.java
@@ -126,7 +126,7 @@ public class FunctionGenerator {
 
     private void buildUtilityNodes(Map<String, String> queryMap) {
         Category.Builder utilityBuilder = rootBuilder.stepIn(Category.Name.UTILITIES);
-        DatabaseManager dbManager = new DatabaseManager();
+        DatabaseManager dbManager = DatabaseManager.getInstance();
 
         List<FunctionResult> functionResults = CommonUtils.hasNoKeyword(queryMap, "q") ?
                 dbManager.getAllFunctions(DatabaseManager.FunctionKind.FUNCTION) :

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/db/DatabaseManager.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/db/DatabaseManager.java
@@ -48,6 +48,15 @@ public class DatabaseManager {
     private static final Logger LOGGER = Logger.getLogger(DatabaseManager.class.getName());
     private final String dbPath;
 
+    private static class Holder {
+
+        private static final DatabaseManager INSTANCE = new DatabaseManager();
+    }
+
+    public static DatabaseManager getInstance() {
+        return Holder.INSTANCE;
+    }
+
     public DatabaseManager() {
         try {
             Class.forName("org.sqlite.JDBC");

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ActionCall.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/ActionCall.java
@@ -94,7 +94,7 @@ public class ActionCall extends NodeBuilder {
             return null;
         }
 
-        DatabaseManager dbManager = new DatabaseManager();
+        DatabaseManager dbManager = DatabaseManager.getInstance();
         Optional<FunctionResult> functionResult = codedata.id() != null ? dbManager.getFunction(codedata.id()) :
                 dbManager.getAction(codedata.org(), codedata.module(), codedata.symbol());
         if (functionResult.isEmpty()) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionCall.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionCall.java
@@ -110,7 +110,7 @@ public class FunctionCall extends NodeBuilder {
             return;
         }
 
-        DatabaseManager dbManager = new DatabaseManager();
+        DatabaseManager dbManager = DatabaseManager.getInstance();
         Optional<FunctionResult> functionResult =
                 dbManager.getFunction(codedata.org(), codedata.module(), codedata.symbol(),
                         DatabaseManager.FunctionKind.FUNCTION);
@@ -184,7 +184,7 @@ public class FunctionCall extends NodeBuilder {
     }
 
     private static FlowNode fetchNodeTemplate(NodeBuilder nodeBuilder, Codedata codedata) {
-        DatabaseManager dbManager = new DatabaseManager();
+        DatabaseManager dbManager = DatabaseManager.getInstance();
         Optional<FunctionResult> functionResult =
                 dbManager.getFunction(codedata.org(), codedata.module(), codedata.symbol(),
                         DatabaseManager.FunctionKind.FUNCTION);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnection.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/NewConnection.java
@@ -92,7 +92,7 @@ public class NewConnection extends NodeBuilder {
     }
 
     private static FlowNode fetchNodeTemplate(NodeBuilder nodeBuilder, Codedata codedata) {
-        DatabaseManager dbManager = new DatabaseManager();
+        DatabaseManager dbManager = DatabaseManager.getInstance();
         Optional<FunctionResult> functionResult = codedata.id() != null ? dbManager.getFunction(codedata.id()) :
                 dbManager.getFunction(codedata.org(), codedata.module(), codedata.symbol(),
                         DatabaseManager.FunctionKind.CONNECTOR);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/module-info.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module io.ballerina.flow.model.generator {
     requires io.ballerina.openapi.core;
     requires io.swagger.v3.oas.models;
     requires jakarta.persistence;
+    requires org.xerial.sqlitejdbc;
 
     exports io.ballerina.flowmodelgenerator.core;
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/build.gradle
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/build.gradle
@@ -115,6 +115,20 @@ def pullBallerinaModule(String packageName) {
     }
 }
 
+// TODO: This should be removed once https://github.com/ballerina-platform/ballerina-distribution/issues/5811 is completed
+shadowJar {
+    archiveBaseName.set(project.name)
+    archiveClassifier.set('')
+    archiveVersion.set(project.version.toString())
+    configurations = [project.configurations.runtimeClasspath]
+    dependencies {
+        include(dependency("org.xerial:sqlite-jdbc:${sqliteJdbcVersion}"))
+        exclude('META-INF/*.SF')
+        exclude('META-INF/*.DSA')
+        exclude('META-INF/*.RSA')
+    }
+}
+
 test.dependsOn pullBallerinaModule('ballerinax/redis')
 test.dependsOn pullBallerinaModule('ballerinax/trigger.salesforce')
 
@@ -130,7 +144,6 @@ test {
 }
 
 ext.moduleName = 'io.ballerina.flowmodelgenerator.extension'
-
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     dependsOn configurations.dist
@@ -146,4 +159,8 @@ compileJava {
         ]
         classpath = files()
     }
+}
+
+artifacts {
+    archives shadowJar
 }


### PR DESCRIPTION
## Purpose
Since SQLite is not bundled with the distribution, the local index does not function with the latest extension. As a temporary measure, a FAT JAR that includes SQLite has been bundled with the LS extension. This workaround should be reversed once the issue detailed in https://github.com/ballerina-platform/ballerina-distribution/issues/5811 is resolved.