### PR TITLE
Fix linerangeAdjust the line range of the block node.  Update the line range to ensure text edits point to content within the braces, excluding the braces themselves.

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CommonUtils.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CommonUtils.java
@@ -36,6 +36,7 @@ import io.ballerina.compiler.api.symbols.resourcepath.PathSegmentList;
 import io.ballerina.compiler.api.symbols.resourcepath.ResourcePath;
 import io.ballerina.compiler.syntax.tree.BindingPatternNode;
 import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.ChildNodeList;
 import io.ballerina.compiler.syntax.tree.DoStatementNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -493,5 +494,29 @@ public class CommonUtils {
                 break;
         }
         return diagnostic;
+    }
+
+    /**
+     * Get the line range of a block node, excluding the opening and closing braces if they exist.
+     *
+     * @param node the block node
+     * @return the line range of the block node
+     */
+    public static LineRange getLineRangeOfBlockNode(NonTerminalNode node) {
+        ChildNodeList children = node.children();
+        int size = children.size();
+
+        if (size < 2) {
+            return node.lineRange();
+        }
+
+        Node startToken = children.get(0);
+        Node endToken = children.get(size - 1);
+
+        if (startToken.kind() == SyntaxKind.OPEN_BRACE_TOKEN && endToken.kind() == SyntaxKind.CLOSE_BRACE_TOKEN) {
+            return LineRange.from(node.lineRange().fileName(), startToken.lineRange().endLine(),
+                    endToken.lineRange().startLine());
+        }
+        return node.lineRange();
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ErrorHandlerGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ErrorHandlerGenerator.java
@@ -90,7 +90,7 @@ public class ErrorHandlerGenerator {
             }
 
             // Generate the text edits
-            LineRange childLineRange = functionBodyNode.lineRange();
+            LineRange childLineRange = CommonUtils.getLineRangeOfBlockNode(functionBodyNode);
             textEdits.add(new TextEdit(CommonUtils.toRange(childLineRange.startLine()), prefix));
             textEdits.add(new TextEdit(CommonUtils.toRange(childLineRange.endLine()), suffix));
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/config/single.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/config/single.json
@@ -7,11 +7,11 @@
         "range": {
           "start": {
             "line": 5,
-            "character": 47
+            "character": 48
           },
           "end": {
             "line": 5,
-            "character": 47
+            "character": 48
           }
         },
         "newText": "do {\n"
@@ -20,11 +20,11 @@
         "range": {
           "start": {
             "line": 11,
-            "character": 1
+            "character": 0
           },
           "end": {
             "line": 11,
-            "character": 1
+            "character": 0
           }
         },
         "newText": "\n} on fail error e {\n\n}"
@@ -33,11 +33,11 @@
         "range": {
           "start": {
             "line": 29,
-            "character": 41
+            "character": 42
           },
           "end": {
             "line": 29,
-            "character": 41
+            "character": 42
           }
         },
         "newText": "do {\n"
@@ -46,11 +46,11 @@
         "range": {
           "start": {
             "line": 39,
-            "character": 1
+            "character": 0
           },
           "end": {
             "line": 39,
-            "character": 1
+            "character": 0
           }
         },
         "newText": "\n} on fail error e {\n\n}"
@@ -59,11 +59,11 @@
         "range": {
           "start": {
             "line": 51,
-            "character": 51
+            "character": 52
           },
           "end": {
             "line": 51,
-            "character": 51
+            "character": 52
           }
         },
         "newText": "do {\n"
@@ -72,11 +72,11 @@
         "range": {
           "start": {
             "line": 53,
-            "character": 5
+            "character": 4
           },
           "end": {
             "line": 53,
-            "character": 5
+            "character": 4
           }
         },
         "newText": "\n} on fail error e {\n\n}"


### PR DESCRIPTION
## Purpose
Adjust the line range of the block node.

$title to point to content within the braces, excluding the braces themselves.