### PR TITLE
Remove the node template cache

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/NodeTemplateGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/NodeTemplateGenerator.java
@@ -7,13 +7,10 @@ import com.google.gson.JsonObject;
 import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.flowmodelgenerator.core.model.FlowNode;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
-import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Generates the node template for the given node kind.
@@ -24,25 +21,13 @@ public class NodeTemplateGenerator {
 
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
 
-    private static final Map<Codedata, FlowNode> nodeCache = new HashMap<>();
-
     public JsonElement getNodeTemplate(WorkspaceManager workspaceManager, Path filePath, LinePosition position,
                                        JsonObject id) {
         Codedata codedata = gson.fromJson(id, Codedata.class);
-        FlowNode flowNode = nodeCache.get(codedata);
-        if (flowNode != null) {
-            return gson.toJsonTree(flowNode);
-        }
-
-        flowNode = NodeBuilder.getNodeFromKind(codedata.node())
+        FlowNode flowNode = NodeBuilder.getNodeFromKind(codedata.node())
                 .setConstData()
                 .setTemplateData(new NodeBuilder.TemplateContext(workspaceManager, filePath, position, codedata))
                 .build();
-
-        // TODO: Need to keep an array on which nodes are note not cacheable
-        if (codedata.node() != NodeKind.DATA_MAPPER) {
-            nodeCache.put(codedata, flowNode);
-        }
         return gson.toJsonTree(flowNode);
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-main.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-main.json
@@ -25,7 +25,7 @@
           "description": "Name of the variable"
         },
         "valueType": "IDENTIFIER",
-        "value": "var1",
+        "value": "var2",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -49,6 +49,7 @@
         "valueType": "MULTIPLE_SELECT",
         "valueTypeConstraint": [
           "Address address",
+          "Address var1",
           "Address[] addresses",
           "Input moduleInput",
           "http:Client httpClient",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-service.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-service.json
@@ -25,7 +25,7 @@
           "description": "Name of the variable"
         },
         "valueType": "IDENTIFIER",
-        "value": "var1",
+        "value": "var2",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -48,6 +48,7 @@
         },
         "valueType": "MULTIPLE_SELECT",
         "valueTypeConstraint": [
+          "Address var1",
           "Address[] addresses",
           "Input localInput",
           "Input moduleInput",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/variable.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/variable.json
@@ -1,4 +1,9 @@
 {
+  "source": "data_mapper/main.bal",
+  "position": {
+    "line": 14,
+    "offset": 0
+  },
   "description": "Sample diagram node",
   "codedata": {
     "node": "VARIABLE"
@@ -20,7 +25,7 @@
           "description": "Name of the variable"
         },
         "valueType": "IDENTIFIER",
-        "value": "var1",
+        "value": "var2",
         "optional": false,
         "editable": true,
         "advanced": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/source/data_mapper/main.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/source/data_mapper/main.bal
@@ -31,3 +31,4 @@ function fn(int x) returns int {
 http:Client httpClientResult = check new ("http://localhost:9091");
 
 final Address[] addresses = [];
+final Address var1 = {country: "", city: "", houseNo: "", line2: "", line1: ""};


### PR DESCRIPTION
## Purpose

Since variable names are generated for each request, the cache is returning values from the previous request. This causes the "variable already declared" diagnostic in subsequent requests.