### PR TITLE
Modify the function signature if it lacks the error type

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/config/error.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/config/error.json
@@ -1,0 +1,203 @@
+{
+  "description": "",
+  "source": "error.bal",
+  "output": {
+    "error.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 5,
+            "character": 46
+          },
+          "end": {
+            "line": 5,
+            "character": 46
+          }
+        },
+        "newText": "|error"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 5,
+            "character": 48
+          },
+          "end": {
+            "line": 5,
+            "character": 48
+          }
+        },
+        "newText": "do {\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 0
+          },
+          "end": {
+            "line": 11,
+            "character": 0
+          }
+        },
+        "newText": "\n} on fail var e {\n   return e;\n}"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 13,
+            "character": 55
+          },
+          "end": {
+            "line": 13,
+            "character": 55
+          }
+        },
+        "newText": "|error"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 13,
+            "character": 57
+          },
+          "end": {
+            "line": 13,
+            "character": 57
+          }
+        },
+        "newText": "do {\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 18,
+            "character": 0
+          },
+          "end": {
+            "line": 18,
+            "character": 0
+          }
+        },
+        "newText": "\n} on fail var e {\n   return e;\n}"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 20,
+            "character": 40
+          },
+          "end": {
+            "line": 20,
+            "character": 40
+          }
+        },
+        "newText": "|error"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 20,
+            "character": 42
+          },
+          "end": {
+            "line": 20,
+            "character": 42
+          }
+        },
+        "newText": "do {\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 30,
+            "character": 0
+          },
+          "end": {
+            "line": 30,
+            "character": 0
+          }
+        },
+        "newText": "\n} on fail var e {\n   return e;\n}"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 32,
+            "character": 18
+          },
+          "end": {
+            "line": 32,
+            "character": 18
+          }
+        },
+        "newText": " returns error?"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 32,
+            "character": 20
+          },
+          "end": {
+            "line": 32,
+            "character": 20
+          }
+        },
+        "newText": "do {\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 34,
+            "character": 0
+          },
+          "end": {
+            "line": 34,
+            "character": 0
+          }
+        },
+        "newText": "\n} on fail var e {\n   return e;\n}"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 38,
+            "character": 54
+          },
+          "end": {
+            "line": 38,
+            "character": 54
+          }
+        },
+        "newText": "|error"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 38,
+            "character": 56
+          },
+          "end": {
+            "line": 38,
+            "character": 56
+          }
+        },
+        "newText": "do {\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 40,
+            "character": 4
+          },
+          "end": {
+            "line": 40,
+            "character": 4
+          }
+        },
+        "newText": "\n} on fail var e {\n   return e;\n}"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/config/single.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/config/single.json
@@ -7,11 +7,11 @@
         "range": {
           "start": {
             "line": 5,
-            "character": 48
+            "character": 54
           },
           "end": {
             "line": 5,
-            "character": 48
+            "character": 54
           }
         },
         "newText": "do {\n"
@@ -27,17 +27,30 @@
             "character": 0
           }
         },
-        "newText": "\n} on fail error e {\n\n}"
+        "newText": "\n} on fail var e {\n   return e;\n}"
       },
       {
         "range": {
           "start": {
             "line": 29,
-            "character": 42
+            "character": 57
           },
           "end": {
             "line": 29,
-            "character": 42
+            "character": 57
+          }
+        },
+        "newText": "|error"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 29,
+            "character": 59
+          },
+          "end": {
+            "line": 29,
+            "character": 59
           }
         },
         "newText": "do {\n"
@@ -53,17 +66,30 @@
             "character": 0
           }
         },
-        "newText": "\n} on fail error e {\n\n}"
+        "newText": "\n} on fail var e {\n   return e;\n}"
       },
       {
         "range": {
           "start": {
             "line": 51,
-            "character": 52
+            "character": 56
           },
           "end": {
             "line": 51,
-            "character": 52
+            "character": 56
+          }
+        },
+        "newText": "|error"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 51,
+            "character": 58
+          },
+          "end": {
+            "line": 51,
+            "character": 58
           }
         },
         "newText": "do {\n"
@@ -79,7 +105,7 @@
             "character": 4
           }
         },
-        "newText": "\n} on fail error e {\n\n}"
+        "newText": "\n} on fail var e {\n   return e;\n}"
       }
     ]
   }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/source/error.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/source/error.bal
@@ -1,0 +1,42 @@
+import ballerina/http;
+import ballerina/io;
+
+final http:Client foodClient = check new ("http://localhost:9090");
+
+function greetUser(string name) returns string {
+    string greeting = "Hello, " + name;
+    io:println(greeting);
+    string response = "Welcome to Ballerina!";
+    io:println(response);
+    return greeting + " " + response;
+}
+
+function exitUser(string name) returns string[]|boolean {
+    string farewell = "Goodbye, " + name;
+    io:println(farewell);
+    string[] responses = ["Goodbye", "See you later"];
+    return responses;
+}
+
+function getPineapples() returns string? {
+    string? msg;
+    do {
+        json res = check foodClient->get("/western/pineapples");
+        msg = res.toString();
+        return msg;
+    } on fail http:ClientError err {
+        msg = err.message();
+        return msg;
+    }
+}
+
+function emptyFn() {
+
+}
+
+service /food on new http:Listener(9090) {
+
+    resource function get pineapples() returns string? {
+        return getPineapples();
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/source/single.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/source/single.bal
@@ -3,7 +3,7 @@ import ballerina/io;
 
 final http:Client foodClient = check new ("http://localhost:9090");
 
-function greetUser(string name) returns string {
+function greetUser(string name) returns string|error {
     string greeting = "Hello, " + name;
     io:println(greeting);
     string response = "Welcome to Ballerina!";
@@ -27,7 +27,7 @@ function getOranges() returns string {
     }
 }
 
-function getPineapples() returns string? {
+function getPineapples() returns string|http:ClientError? {
     string? msg;
     do {
         json res = check foodClient->get("/western/pineapples");
@@ -49,7 +49,7 @@ service /food on new http:Listener(9090) {
         }
     }
 
-    resource function get oranges() returns string {
+    resource function get oranges() returns string|error {
         return getOranges();
     }
 


### PR DESCRIPTION
## Purpose
When the error handler cannot return a non-error value, a diagnostic is generated due to a function signature mismatch. To address this, the error handler will default to returning the added error. Users are responsible for making any necessary adjustments thereafter.