### PR TITLE
Avoid adding error handlers to expression-bodied functions

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ErrorHandlerGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ErrorHandlerGenerator.java
@@ -99,6 +99,12 @@ public class ErrorHandlerGenerator {
         public void visit(FunctionDefinitionNode functionDefinitionNode) {
             // Check if the function already contains a global error handler
             FunctionBodyNode functionBodyNode = functionDefinitionNode.functionBody();
+
+            // Ignore if the function body is an expression bodied function
+            if (functionBodyNode.kind() == SyntaxKind.EXPRESSION_FUNCTION_BODY) {
+                return;
+            }
+
             ChildNodeList children = functionBodyNode.children();
             if (children.size() == 3 && children.get(1).kind() == SyntaxKind.DO_STATEMENT) {
                 return;

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ErrorHandlerGeneratorTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ErrorHandlerGeneratorTest.java
@@ -41,8 +41,7 @@ import java.util.Map;
  */
 public class ErrorHandlerGeneratorTest extends AbstractLSTest {
 
-    private static final Type textEditListType = new TypeToken<Map<String, List<TextEdit>>>() {
-    }.getType();
+    private static final Type textEditListType = new TypeToken<Map<String, List<TextEdit>>>() { }.getType();
 
     @Override
     @Test(dataProvider = "data-provider")
@@ -96,7 +95,6 @@ public class ErrorHandlerGeneratorTest extends AbstractLSTest {
     protected String getApiName() {
         return "addErrorHandler";
     }
-
 
     private record TestConfig(String description, String source, Map<String, List<TextEdit>> output) {
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/config/mapping.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/config/mapping.json
@@ -1,0 +1,47 @@
+{
+  "description": "",
+  "source": "mapping.bal",
+  "output": {
+    "mapping.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 16,
+            "character": 61
+          },
+          "end": {
+            "line": 16,
+            "character": 61
+          }
+        },
+        "newText": "|error"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 16,
+            "character": 62
+          },
+          "end": {
+            "line": 16,
+            "character": 62
+          }
+        },
+        "newText": "do {\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 21,
+            "character": 2
+          },
+          "end": {
+            "line": 21,
+            "character": 2
+          }
+        },
+        "newText": "\n} on fail var e {\n   return e;\n}"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/source/mapping.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/error_handler_generator/source/mapping.bal
@@ -1,0 +1,23 @@
+type UserInfo record {|
+    readonly string username;
+    string password;
+    Address address;
+|};
+
+type Address record {|
+    string city;
+    string country;
+|};
+
+public function foo(int i, UserInfo userInfo) returns Address => {
+    country: "",
+    city: ""
+};
+
+public function bar(int i, UserInfo userInfo) returns Address {
+    return {
+        country: "",
+        city: ""
+    };
+};
+


### PR DESCRIPTION
## Purpose
$title as expression-bodied functions serve as simple data mappings, making global error handlers unnecessary.