### PR TITLE
Update the Github workflows

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -22,6 +22,11 @@ jobs:
           distribution: 'temurin'
           java-version: 21.0.3
 
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.1
+        with:
+          version: latest
+
       - name: Change to Timestamped Version
         run: |
           startTime=$(TZ="Asia/Kolkata" date +'%Y%m%d-%H%M00')

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21.0.3
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.1
+        with:
+          version: latest
+
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
@@ -45,6 +51,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21.0.3
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.1
+        with:
+          version: latest
+
       - name: Build with Gradle
         env:
           packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21.0.3
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.1
+        with:
+          version: latest
+
       - name: Set version env variable
         run: echo VERSION=$((grep -w "version" | cut -d= -f2) < gradle.properties | cut -d- -f1) >> $GITHUB_ENV
       - name: Pre release depenency version update

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build -x :docerina-ui:npmTestDocerinaUI
+        run: ./gradlew build -x :createArtifactZip -x :docerina-ui:npmTestDocerinaUI
 
       - name: Generate Codecov Report
         if: github.event_name == 'pull_request'
@@ -61,7 +61,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew.bat build -x :docerina-ui:npmTestDocerinaUI
+        run: ./gradlew.bat build -x :createArtifactZip -x :docerina-ui:npmTestDocerinaUI
 
   windows-build-2:
 
@@ -92,6 +92,6 @@ jobs:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew.bat build -x :docerina-ui:npmTestDocerinaUI -x test
+          ./gradlew.bat build -x :createArtifactZip -x :docerina-ui:npmTestDocerinaUI -x test
           ./gradlew.bat :flow-model-generator:flow-model-generator-ls-extension:test
         working-directory: ${{ github.workspace }}/test folder


### PR DESCRIPTION
## Purpose
This PR addresses the following changes:

1. Remove building of Testerina and Docerina from the `pull-request` build, since these tools haven't been updated recently and the npm build isn't necessary for other extensions.
2. Set up Ballerina in other workflows, as it's required for building the flow model extension.