### PR TITLE
Add the `var` type descriptor to the default statement in the expression editor

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ExpressionEditorContext.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ExpressionEditorContext.java
@@ -170,7 +170,7 @@ public class ExpressionEditorContext {
      * @return the line range of the generated statement.
      */
     public LineRange generateStatement() {
-        String prefix = "_ = ";
+        String prefix = "var _ = ";
         Optional<Property> optionalProperty = getProperty();
         List<TextEdit> textEdits = new ArrayList<>();
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj1.json
@@ -71,7 +71,7 @@
       "label": "error",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "P",
+      "sortText": "AL",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -535,7 +535,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \nPerforms a safe division operation.\n\nThis function divides the given numerator by the denominator and returns the result.\nIf the denominator is zero, it returns an error indicating a division by zero.\n  \n**Params**  \n- `float` a: The numerator of type `float`.  \n- `float` b: The denominator of type `float`.\n\n# Returns\n- `float` - The result of the division if the denominator is not zero.\n- `error` - An error indicating division by zero if the denominator is zero.\n  \n  \n**Return** `float|error`   \n- The result of the division or an error.  \n  \n"
         }
       },
-      "sortText": "G",
+      "sortText": "AC",
       "filterText": "safeDivide",
       "insertText": "safeDivide(${1})",
       "insertTextFormat": "Snippet",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj2.json
@@ -71,7 +71,7 @@
       "label": "error",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "P",
+      "sortText": "AL",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -390,7 +390,7 @@
       "label": "Address",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "Q",
+      "sortText": "AM",
       "insertText": "Address",
       "insertTextFormat": "Snippet"
     },
@@ -398,7 +398,7 @@
       "label": "Admission",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "Q",
+      "sortText": "AM",
       "insertText": "Admission",
       "insertTextFormat": "Snippet"
     },
@@ -406,7 +406,7 @@
       "label": "Employee",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "Q",
+      "sortText": "AM",
       "insertText": "Employee",
       "insertTextFormat": "Snippet"
     },
@@ -414,7 +414,7 @@
       "label": "Location",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "Q",
+      "sortText": "AM",
       "insertText": "Location",
       "insertTextFormat": "Snippet"
     },
@@ -422,7 +422,7 @@
       "label": "MyOk",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "Q",
+      "sortText": "AM",
       "insertText": "MyOk",
       "insertTextFormat": "Snippet"
     },
@@ -430,7 +430,7 @@
       "label": "Person",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "Q",
+      "sortText": "AM",
       "insertText": "Person",
       "insertTextFormat": "Snippet"
     },
@@ -441,7 +441,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "Q",
+      "sortText": "AM",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -463,7 +463,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \nAdds two integers and returns the result.\n\n```\nint result = add(5, 3);\n// result will be 8\n```  \n**Params**  \n- `int` a: The first integer to be added  \n- `int` b: The second integer to be added\n  \n  \n**Return** `int`   \n- The sum of the two integers  \n  \n# Example  \n  \n"
         }
       },
-      "sortText": "G",
+      "sortText": "AC",
       "filterText": "add",
       "insertText": "add(${1})",
       "insertTextFormat": "Snippet",
@@ -501,7 +501,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \n  \n"
         }
       },
-      "sortText": "ZD",
+      "sortText": "AZ",
       "filterText": "main",
       "insertText": "main()",
       "insertTextFormat": "Snippet"
@@ -524,7 +524,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \nComputes the prefix sum of an array of integers.\n\nThe prefix sum of an array is a new array where each element at index `i` is the sum of the elements\nfrom the start of the array up to index `i`.\n  \n**Params**  \n- `int[]` numbers: The array of integers for which the prefix sum is to be computed.  \n  \n**Return** `int[]`   \n- An array of integers representing the prefix sum of the input array.  \n  \n"
         }
       },
-      "sortText": "G",
+      "sortText": "AC",
       "filterText": "prefixSum",
       "insertText": "prefixSum(${1})",
       "insertTextFormat": "Snippet",
@@ -543,7 +543,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \nPerforms a safe division operation.\n\nThis function divides the given numerator by the denominator and returns the result.\nIf the denominator is zero, it returns an error indicating a division by zero.\n  \n**Params**  \n- `float` a: The numerator of type `float`.  \n- `float` b: The denominator of type `float`.\n\n# Returns\n- `float` - The result of the division if the denominator is not zero.\n- `error` - An error indicating division by zero if the denominator is zero.\n  \n  \n**Return** `float|error`   \n- The result of the division or an error.  \n  \n"
         }
       },
-      "sortText": "G",
+      "sortText": "AC",
       "filterText": "safeDivide",
       "insertText": "safeDivide(${1})",
       "insertTextFormat": "Snippet",
@@ -562,7 +562,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \n  \n**Params**  \n- `int[]` numbers  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "G",
+      "sortText": "AC",
       "filterText": "sum",
       "insertText": "sum(${1})",
       "insertTextFormat": "Snippet",
@@ -581,7 +581,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \n  \n**Params**  \n- `Person` person  \n- `Admission` admission  \n  \n**Return** `Employee`   \n  \n"
         }
       },
-      "sortText": "G",
+      "sortText": "AC",
       "filterText": "transform",
       "insertText": "transform(${1})",
       "insertTextFormat": "Snippet",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj3.json
@@ -2,12 +2,12 @@
   "description": "",
   "filePath": "proj/fn.bal",
   "context": {
-    "expression": "",
+    "expression": "[]",
     "startLine": {
       "line": 33,
-      "offset": 20
+      "offset": 4
     },
-    "offset": 0,
+    "offset": 1,
     "node": {}
   },
   "completionContext": {
@@ -18,7 +18,7 @@
       "label": "decimal",
       "kind": "TypeParameter",
       "detail": "Decimal",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -26,7 +26,7 @@
       "label": "error",
       "kind": "Event",
       "detail": "Error",
-      "sortText": "BL",
+      "sortText": "N",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
@@ -34,7 +34,7 @@
       "label": "object",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "ARR",
+      "sortText": "R",
       "insertText": "object",
       "insertTextFormat": "Snippet"
     },
@@ -42,7 +42,7 @@
       "label": "transaction",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "ARR",
+      "sortText": "R",
       "insertText": "transaction",
       "insertTextFormat": "Snippet"
     },
@@ -50,7 +50,7 @@
       "label": "xml",
       "kind": "TypeParameter",
       "detail": "Xml",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -58,7 +58,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "ARR",
+      "sortText": "R",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -66,7 +66,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "ARR",
+      "sortText": "R",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -74,7 +74,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "type",
-      "sortText": "ARR",
+      "sortText": "R",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -82,7 +82,7 @@
       "label": "boolean",
       "kind": "TypeParameter",
       "detail": "Boolean",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -90,7 +90,7 @@
       "label": "future",
       "kind": "TypeParameter",
       "detail": "Future",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -98,7 +98,7 @@
       "label": "int",
       "kind": "TypeParameter",
       "detail": "Int",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -106,7 +106,7 @@
       "label": "float",
       "kind": "TypeParameter",
       "detail": "Float",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -114,7 +114,7 @@
       "label": "function",
       "kind": "TypeParameter",
       "detail": "Function",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "function",
       "insertTextFormat": "Snippet"
     },
@@ -122,7 +122,7 @@
       "label": "string",
       "kind": "TypeParameter",
       "detail": "String",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -130,7 +130,7 @@
       "label": "typedesc",
       "kind": "TypeParameter",
       "detail": "Typedesc",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -138,7 +138,7 @@
       "label": "service",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "service",
       "insertText": "service",
       "insertTextFormat": "Snippet"
@@ -147,7 +147,7 @@
       "label": "new",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "new",
       "insertText": "new ",
       "insertTextFormat": "Snippet"
@@ -156,7 +156,7 @@
       "label": "isolated",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "isolated",
       "insertText": "isolated ",
       "insertTextFormat": "Snippet"
@@ -165,7 +165,7 @@
       "label": "transactional",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "transactional",
       "insertText": "transactional",
       "insertTextFormat": "Snippet"
@@ -174,7 +174,7 @@
       "label": "function",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "function",
       "insertText": "function ",
       "insertTextFormat": "Snippet"
@@ -183,7 +183,7 @@
       "label": "let",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "let",
       "insertText": "let",
       "insertTextFormat": "Snippet"
@@ -192,7 +192,7 @@
       "label": "typeof",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "typeof",
       "insertText": "typeof ",
       "insertTextFormat": "Snippet"
@@ -201,7 +201,7 @@
       "label": "trap",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "trap",
       "insertText": "trap",
       "insertTextFormat": "Snippet"
@@ -210,7 +210,7 @@
       "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "client",
       "insertText": "client ",
       "insertTextFormat": "Snippet"
@@ -219,7 +219,7 @@
       "label": "true",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "true",
       "insertText": "true",
       "insertTextFormat": "Snippet"
@@ -228,7 +228,7 @@
       "label": "false",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "false",
       "insertText": "false",
       "insertTextFormat": "Snippet"
@@ -237,7 +237,7 @@
       "label": "null",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "null",
       "insertText": "null",
       "insertTextFormat": "Snippet"
@@ -246,7 +246,7 @@
       "label": "check",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "check",
       "insertText": "check ",
       "insertTextFormat": "Snippet"
@@ -255,7 +255,7 @@
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "checkpanic",
       "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
@@ -264,7 +264,7 @@
       "label": "is",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "is",
       "insertText": "is",
       "insertTextFormat": "Snippet"
@@ -273,7 +273,7 @@
       "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "ATP",
+      "sortText": "R",
       "filterText": "error",
       "insertText": "error(\"${1}\")",
       "insertTextFormat": "Snippet"
@@ -282,7 +282,7 @@
       "label": "object constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "ATP",
+      "sortText": "R",
       "filterText": "object",
       "insertText": "object {${1}}",
       "insertTextFormat": "Snippet"
@@ -291,7 +291,7 @@
       "label": "base16",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "ATP",
+      "sortText": "R",
       "filterText": "base16",
       "insertText": "base16 `${1}`",
       "insertTextFormat": "Snippet"
@@ -300,7 +300,7 @@
       "label": "base64",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "ATP",
+      "sortText": "R",
       "filterText": "base64",
       "insertText": "base64 `${1}`",
       "insertTextFormat": "Snippet"
@@ -309,7 +309,7 @@
       "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "sortText": "AUQ",
+      "sortText": "S",
       "filterText": "from",
       "insertText": "from ",
       "insertTextFormat": "Snippet"
@@ -318,7 +318,7 @@
       "label": "re ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "ATP",
+      "sortText": "R",
       "filterText": "re ``",
       "insertText": "re `${1}`",
       "insertTextFormat": "Snippet"
@@ -327,7 +327,7 @@
       "label": "string ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "ATP",
+      "sortText": "R",
       "filterText": "string ``",
       "insertText": "string `${1}`",
       "insertTextFormat": "Snippet"
@@ -336,7 +336,7 @@
       "label": "xml ``",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "ATP",
+      "sortText": "R",
       "filterText": "xml ``",
       "insertText": "xml `${1}`",
       "insertTextFormat": "Snippet"
@@ -345,7 +345,7 @@
       "label": "Address",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "BM",
+      "sortText": "O",
       "insertText": "Address",
       "insertTextFormat": "Snippet"
     },
@@ -353,7 +353,7 @@
       "label": "Admission",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "BM",
+      "sortText": "O",
       "insertText": "Admission",
       "insertTextFormat": "Snippet"
     },
@@ -361,7 +361,7 @@
       "label": "Employee",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "BM",
+      "sortText": "O",
       "insertText": "Employee",
       "insertTextFormat": "Snippet"
     },
@@ -369,7 +369,7 @@
       "label": "Location",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "BM",
+      "sortText": "O",
       "insertText": "Location",
       "insertTextFormat": "Snippet"
     },
@@ -377,7 +377,7 @@
       "label": "MyOk",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "BM",
+      "sortText": "O",
       "insertText": "MyOk",
       "insertTextFormat": "Snippet"
     },
@@ -385,7 +385,7 @@
       "label": "Person",
       "kind": "Struct",
       "detail": "Record",
-      "sortText": "BM",
+      "sortText": "O",
       "insertText": "Person",
       "insertTextFormat": "Snippet"
     },
@@ -396,7 +396,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "BM",
+      "sortText": "O",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -404,7 +404,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Union",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -418,7 +418,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \nAdds two integers and returns the result.\n\n```\nint result = add(5, 3);\n// result will be 8\n```  \n**Params**  \n- `int` a: The first integer to be added  \n- `int` b: The second integer to be added\n  \n  \n**Return** `int`   \n- The sum of the two integers  \n  \n# Example  \n  \n"
         }
       },
-      "sortText": "AACC",
+      "sortText": "E",
       "filterText": "add",
       "insertText": "add(${1})",
       "insertTextFormat": "Snippet",
@@ -437,7 +437,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \n  \n**Params**  \n- `string` name  \n  \n**Return** `string`   \n  \n"
         }
       },
-      "sortText": "AGC",
+      "sortText": "E",
       "filterText": "greet",
       "insertText": "greet(${1})",
       "insertTextFormat": "Snippet",
@@ -456,7 +456,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \n  \n"
         }
       },
-      "sortText": "AZDZ",
+      "sortText": "ZB",
       "filterText": "main",
       "insertText": "main()",
       "insertTextFormat": "Snippet"
@@ -465,7 +465,7 @@
       "label": "numbers",
       "kind": "Variable",
       "detail": "int[]",
-      "sortText": "AFB",
+      "sortText": "D",
       "insertText": "numbers",
       "insertTextFormat": "Snippet"
     },
@@ -479,7 +479,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \nComputes the prefix sum of an array of integers.\n\nThe prefix sum of an array is a new array where each element at index `i` is the sum of the elements\nfrom the start of the array up to index `i`.\n  \n**Params**  \n- `int[]` numbers: The array of integers for which the prefix sum is to be computed.  \n  \n**Return** `int[]`   \n- An array of integers representing the prefix sum of the input array.  \n  \n"
         }
       },
-      "sortText": "AGC",
+      "sortText": "E",
       "filterText": "prefixSum",
       "insertText": "prefixSum(${1})",
       "insertTextFormat": "Snippet",
@@ -487,14 +487,6 @@
         "title": "editor.action.triggerParameterHints",
         "command": "editor.action.triggerParameterHints"
       }
-    },
-    {
-      "label": "result",
-      "kind": "Variable",
-      "detail": "int[]",
-      "sortText": "AFB",
-      "insertText": "result",
-      "insertTextFormat": "Snippet"
     },
     {
       "label": "safeDivide(float a, float b)",
@@ -506,7 +498,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \nPerforms a safe division operation.\n\nThis function divides the given numerator by the denominator and returns the result.\nIf the denominator is zero, it returns an error indicating a division by zero.\n  \n**Params**  \n- `float` a: The numerator of type `float`.  \n- `float` b: The denominator of type `float`.\n\n# Returns\n- `float` - The result of the division if the denominator is not zero.\n- `error` - An error indicating division by zero if the denominator is zero.\n  \n  \n**Return** `float|error`   \n- The result of the division or an error.  \n  \n"
         }
       },
-      "sortText": "AGC",
+      "sortText": "E",
       "filterText": "safeDivide",
       "insertText": "safeDivide(${1})",
       "insertTextFormat": "Snippet",
@@ -525,7 +517,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \n  \n**Params**  \n- `int[]` numbers  \n  \n**Return** `int`   \n  \n"
         }
       },
-      "sortText": "AACC",
+      "sortText": "E",
       "filterText": "sum",
       "insertText": "sum(${1})",
       "insertTextFormat": "Snippet",
@@ -544,7 +536,7 @@
           "value": "**Package:** _nipunaf/proj:0.1.0_  \n  \n  \n**Params**  \n- `Person` person  \n- `Admission` admission  \n  \n**Return** `Employee`   \n  \n"
         }
       },
-      "sortText": "AGC",
+      "sortText": "E",
       "filterText": "transform",
       "insertText": "transform(${1})",
       "insertTextFormat": "Snippet",
@@ -557,7 +549,7 @@
       "label": "readonly",
       "kind": "TypeParameter",
       "detail": "Readonly",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -565,7 +557,7 @@
       "label": "handle",
       "kind": "TypeParameter",
       "detail": "Handle",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -573,7 +565,7 @@
       "label": "never",
       "kind": "TypeParameter",
       "detail": "Never",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -581,7 +573,7 @@
       "label": "json",
       "kind": "TypeParameter",
       "detail": "Json",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -589,7 +581,7 @@
       "label": "anydata",
       "kind": "TypeParameter",
       "detail": "Anydata",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -597,7 +589,7 @@
       "label": "any",
       "kind": "TypeParameter",
       "detail": "Any",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -605,26 +597,8 @@
       "label": "byte",
       "kind": "TypeParameter",
       "detail": "Byte",
-      "sortText": "BN",
+      "sortText": "P",
       "insertText": "byte",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "...result",
-      "kind": "Variable",
-      "detail": "int[]",
-      "sortText": "AAC",
-      "filterText": "result",
-      "insertText": "...result",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "...prefixSum(int[] numbers)",
-      "kind": "Function",
-      "detail": "int[]",
-      "sortText": "AAD",
-      "filterText": "prefixSum",
-      "insertText": "...prefixSum(${1})",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/variable1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/variable1.json
@@ -1,0 +1,74 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "121",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "node": {
+      "id": "32874",
+      "metadata": {
+        "label": "Variable",
+        "description": "Assign a value to a variable"
+      },
+      "codedata": {
+        "node": "VARIABLE",
+        "lineRange": {
+          "fileName": "new_data.bal",
+          "startLine": {
+            "line": 1,
+            "offset": 4
+          },
+          "endLine": {
+            "line": 1,
+            "offset": 14
+          }
+        },
+        "sourceCode": "int i = 12;"
+      },
+      "returning": false,
+      "properties": {
+        "expression": {
+          "metadata": {
+            "label": "Expression",
+            "description": "Initialize with value"
+          },
+          "valueType": "EXPRESSION",
+          "value": "12",
+          "optional": true,
+          "editable": true,
+          "advanced": false
+        },
+        "variable": {
+          "metadata": {
+            "label": "Name",
+            "description": "Name of the variable"
+          },
+          "valueType": "IDENTIFIER",
+          "value": "i",
+          "optional": false,
+          "editable": true,
+          "advanced": false
+        },
+        "type": {
+          "metadata": {
+            "label": "Type",
+            "description": "Type of the variable"
+          },
+          "valueType": "TYPE",
+          "value": "",
+          "placeholder": "var",
+          "optional": false,
+          "editable": true,
+          "advanced": false
+        }
+      },
+      "flags": 0
+    },
+    "property": "expression"
+  },
+  "diagnostics": []
+}


### PR DESCRIPTION
## Purpose
For cases such as the config variables, the statement is injected to the module level, and an assignment statement like`_ = 12`is invalid. Hence, adding the type`var`if the type is not specific in the provided node.