### PR TITLE
Implement a LS API to the generate function call template

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/FunctionCallTemplateRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/FunctionCallTemplateRequest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension.request;
+
+import io.ballerina.flowmodelgenerator.core.model.Codedata;
+
+/**
+ * Represents a request for function call template.
+ *
+ * @param filePath  The file path which contains the expression
+ * @param codedata  The code data containing function information
+ * @param kind      The kind of template to generate (CURRENT/IMPORT/AVAILABLE)
+ * @since 2.0.0
+ */
+public record FunctionCallTemplateRequest(String filePath, Codedata codedata, FunctionCallTemplateKind kind) {
+    
+    /**
+     * Represents the kind of function call template.
+     * 
+     * @since 2.0.0
+     */
+    public enum FunctionCallTemplateKind {
+        CURRENT,
+        IMPORTED,
+        AVAILABLE
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/response/FunctionCallTemplateResponse.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/response/FunctionCallTemplateResponse.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  of any KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension.response;
+
+/**
+ * Response class for function call template.
+ *
+ * @since 2.0.0
+ */
+public class FunctionCallTemplateResponse extends AbstractFlowModelResponse {
+    private String template;
+
+    public void setTemplate(String template) {
+        this.template = template;
+    }
+
+    public String template() {
+        return template;
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionCallTemplateTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionCallTemplateTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension;
+
+import io.ballerina.flowmodelgenerator.core.model.Codedata;
+import io.ballerina.flowmodelgenerator.extension.request.FunctionCallTemplateRequest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Tests for the function call template service.
+ *
+ * @since 1.4.0
+ */
+public class FunctionCallTemplateTest extends AbstractLSTest {
+
+    @Override
+    @Test(dataProvider = "data-provider")
+    public void test(Path config) throws IOException {
+        Path configJsonPath = configDir.resolve(config);
+        TestConfig testConfig = gson.fromJson(Files.newBufferedReader(configJsonPath), TestConfig.class);
+        String sourcePath = getSourcePath(testConfig.filePath());
+
+        notifyDidOpen(sourcePath);
+        FunctionCallTemplateRequest request = new FunctionCallTemplateRequest(sourcePath, testConfig.codedata(),
+                testConfig.kind());
+        String template = getResponse(request).getAsJsonPrimitive("template").getAsString();
+        notifyDidClose(sourcePath);
+
+        if (!template.equals(testConfig.functionCall())) {
+            TestConfig updatedConfig =
+                    new TestConfig(testConfig.description(), testConfig.filePath(), testConfig.codedata(),
+                            testConfig.kind(), template);
+            // updateConfig(configJsonPath, updatedConfig);
+            Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
+        }
+    }
+
+    @Override
+    protected String getResourceDir() {
+        return "function_call_template";
+    }
+
+    @Override
+    protected Class<? extends AbstractLSTest> clazz() {
+        return FunctionCallTemplateTest.class;
+    }
+
+    @Override
+    protected String getApiName() {
+        return "functionCallTemplate";
+    }
+
+    @Override
+    protected String getServiceName() {
+        return "expressionEditor";
+    }
+
+    private record TestConfig(String description, String filePath, Codedata codedata,
+                              FunctionCallTemplateRequest.FunctionCallTemplateKind kind, String functionCall) {
+
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/config1.json
@@ -1,0 +1,10 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "codedata": {
+    "node": "FUNCTION_CALL",
+    "symbol": "fn"
+  },
+  "kind": "CURRENT",
+  "functionCall": "fn(${1})"
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/config2.json
@@ -1,0 +1,13 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "codedata": {
+    "node": "FUNCTION_CALL",
+    "org": "ballerina",
+    "module": "io",
+    "symbol": "println",
+    "version": "1.6.1"
+  },
+  "kind": "IMPORTED",
+  "functionCall": "io:println(${1})"
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/config3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/config3.json
@@ -1,0 +1,13 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "codedata": {
+    "node": "FUNCTION_CALL",
+    "org": "ballerina",
+    "module": "io",
+    "symbol": "println",
+    "version": "1.6.1"
+  },
+  "kind": "AVAILABLE",
+  "functionCall": "io:println(${1})"
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/config4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/config4.json
@@ -1,0 +1,13 @@
+{
+    "description": "",
+    "filePath": "source.bal",
+    "codedata": {
+        "node": "FUNCTION_CALL",
+        "org": "ballerina",
+        "module": "log",
+        "symbol": "printInfo",
+        "version": "2.10.0"
+    },
+    "kind": "AVAILABLE",
+    "functionCall": "log:printInfo(${1})"
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/source/source.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/source/source.bal
@@ -4,3 +4,7 @@ public function testFunctionCall() {
     int result = 10;
     io:println("Result: ", result);
 }
+
+function fn() {
+
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/source/source.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/source/source.bal
@@ -1,0 +1,6 @@
+import ballerina/io;
+
+public function testFunctionCall() {
+    int result = 10;
+    io:println("Result: ", result);
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/testng.xml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/testng.xml
@@ -45,6 +45,7 @@ under the License.
             <class name="io.ballerina.flowmodelgenerator.extension.DataMapManagerTypesTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.ErrorHandlerGeneratorTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.GetEnclosedFunctionDefTest"/>
+            <class name="io.ballerina.flowmodelgenerator.extension.FunctionCallTemplateTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR implements the generation of function call text when a user selects a function from the helper pane. It handles both already imported and not-yet-imported functions.

- **Function Call Generation:** Generates the correct function call text based on whether the function is currently available, imported, or available for import.
- **Import Handling:** Automatically adds necessary import statements to the shadowed project if a selected function is not already imported.
- **Request/Response:**
    - Request: `filepath`, `codedata`, and `kind` (current, import, available).
    - Response: A string `template` representing the function call template.