### PR TITLE
Fix several issues in the http service designer form

### DIFF
--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
@@ -59,6 +59,7 @@ public class ServiceModelGeneratorConstants {
     public static final String VALUE_TYPE_EXPRESSION = "EXPRESSION";
     public static final String VALUE_TYPE_IDENTIFIER = "IDENTIFIER";
     public static final String VALUE_TYPE_TYPE = "TYPE";
+    public static final String HTTP_PARAM_TYPE_QUERY = "QUERY";
 
     public static final String TYPE_HTTP_SERVICE_CONFIG = "http:ServiceConfig";
 

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
@@ -35,6 +35,8 @@ public class ServiceModelGeneratorConstants {
     public static final String SINGLE_SELECT_VALUE = "SINGLE_SELECT";
     public static final String MULTIPLE_SELECT_VALUE = "MULTIPLE_SELECT";
 
+    public static final String HTTP_DEFAULT_LISTENER_REF = "default:httpListener";
+
     public static final String KAFKA = "kafka";
     public static final String HTTP = "http";
     public static final String GRAPHQL = "graphql";

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
@@ -36,6 +36,7 @@ public class ServiceModelGeneratorConstants {
     public static final String MULTIPLE_SELECT_VALUE = "MULTIPLE_SELECT";
 
     public static final String HTTP_DEFAULT_LISTENER_REF = "default:httpListener";
+    public static final String HTTP_DEFAULT_MODULE = "http.default";
 
     public static final String KAFKA = "kafka";
     public static final String HTTP = "http";

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorService.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorService.java
@@ -95,7 +95,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -183,7 +183,7 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
     }
 
     private static Set<String> getCompatibleListeners(String moduleName, SemanticModel semanticModel) {
-        Set<String> listeners = new HashSet<>();
+        Set<String> listeners = new LinkedHashSet<>();
         if (ServiceModelGeneratorConstants.HTTP.equals(moduleName)) {
             listeners.add(ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_REF);
         }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorService.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorService.java
@@ -198,7 +198,7 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
             if (module.isEmpty() || !module.get().id().moduleName().equals(moduleName)) {
                 continue;
             }
-            listeners.add(variableSymbol.getName().orElse(""));
+            variableSymbol.getName().ifPresent(listeners::add);
         }
         return listeners;
     }
@@ -542,21 +542,21 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
             } else {
                 updateServiceModel(serviceModel, serviceNode, semanticModel);
             }
-            Set<String> listenersSet = getCompatibleListeners(serviceName.get(), semanticModel);
+            Set<String> listeners = getCompatibleListeners(serviceName.get(), semanticModel);
             List<String> allValues = serviceModel.getListener().getValues();
             if (allValues.isEmpty()) {
-                listenersSet.add(serviceModel.getListener().getValue());
+                listeners.add(serviceModel.getListener().getValue());
             } else {
-                listenersSet.addAll(allValues);
+                listeners.addAll(allValues);
             }
             Value listener = serviceModel.getListener();
-            if (!listenersSet.isEmpty()) {
+            if (!listeners.isEmpty()) {
                 if (serviceName.get().equals(ServiceModelGeneratorConstants.KAFKA)) {
                     listener.setValueType(ServiceModelGeneratorConstants.SINGLE_SELECT_VALUE);
                 } else {
                     listener.setValueType(ServiceModelGeneratorConstants.MULTIPLE_SELECT_VALUE);
                 }
-                listener.setItems(listenersSet.stream().toList());
+                listener.setItems(listeners.stream().toList());
             }
             return new ServiceFromSourceResponse(serviceModel);
         });

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorService.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorService.java
@@ -181,14 +181,23 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
     }
 
     private static List<String> getCompatibleListeners(String moduleName, SemanticModel semanticModel) {
-        return semanticModel.moduleSymbols().stream()
-                .filter(symbol -> symbol instanceof VariableSymbol)
-                .map(symbol -> (VariableSymbol) symbol)
-                .filter(variableSymbol -> variableSymbol.qualifiers().contains(Qualifier.LISTENER))
-                .filter(variableSymbol -> variableSymbol.typeDescriptor().getModule().isPresent() && variableSymbol
-                        .typeDescriptor().getModule().get().id().moduleName().equals(moduleName))
-                .map(variableSymbol -> variableSymbol.getName().orElse(""))
-                .toList();
+        List<String> listeners = new ArrayList<>();
+        if (ServiceModelGeneratorConstants.HTTP.equals(moduleName)) {
+            listeners.add(ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_REF);
+        }
+
+        for (Symbol moduleSymbol : semanticModel.moduleSymbols()) {
+            if (!(moduleSymbol instanceof VariableSymbol variableSymbol)
+                    || !variableSymbol.qualifiers().contains(Qualifier.LISTENER)) {
+                continue;
+            }
+            Optional<ModuleSymbol> module = variableSymbol.typeDescriptor().getModule();
+            if (module.isEmpty() || !module.get().id().moduleName().equals(moduleName)) {
+                continue;
+            }
+            listeners.add(variableSymbol.getName().orElse(""));
+        }
+        return listeners;
     }
 
     /**

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/Utils.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/Utils.java
@@ -462,7 +462,7 @@ public final class Utils {
         SeparatedNodeList<ParameterNode> parameters = functionSignatureNode.parameters();
         List<Parameter> parameterModels = new ArrayList<>();
         parameters.forEach(parameterNode -> {
-            Optional<Parameter> parameterModel = getParameterModel(parameterNode);
+            Optional<Parameter> parameterModel = getParameterModel(parameterNode, isHttp);
             parameterModel.ifPresent(parameterModels::add);
         });
         functionModel.setParameters(parameterModels);
@@ -508,7 +508,7 @@ public final class Utils {
         SeparatedNodeList<ParameterNode> parameters = functionSignatureNode.parameters();
         List<Parameter> parameterModels = new ArrayList<>();
         parameters.forEach(parameterNode -> {
-            Optional<Parameter> parameterModel = getParameterModel(parameterNode);
+            Optional<Parameter> parameterModel = getParameterModel(parameterNode, isHttp);
             parameterModel.ifPresent(parameterModels::add);
         });
         functionModel.setParameters(parameterModels);
@@ -700,18 +700,18 @@ public final class Utils {
         return Optional.empty();
     }
 
-    public static Optional<Parameter> getParameterModel(ParameterNode parameterNode) {
+    public static Optional<Parameter> getParameterModel(ParameterNode parameterNode, boolean isHttp) {
         if (parameterNode instanceof RequiredParameterNode parameter) {
             String paramName = parameter.paramName().get().toString().trim();
             Parameter parameterModel = createParameter(paramName, ServiceModelGeneratorConstants.KIND_REQUIRED,
                     ServiceModelGeneratorConstants.VALUE_TYPE_IDENTIFIER, parameter.typeName().toString().trim(),
-                    parameter.annotations());
+                    parameter.annotations(), isHttp);
             return Optional.of(parameterModel);
         } else if (parameterNode instanceof DefaultableParameterNode parameter) {
             String paramName = parameter.paramName().get().toString().trim();
             Parameter parameterModel = createParameter(paramName, ServiceModelGeneratorConstants.KIND_DEFAULTABLE,
                     ServiceModelGeneratorConstants.VALUE_TYPE_EXPRESSION, parameter.typeName().toString().trim(),
-                    parameter.annotations());
+                    parameter.annotations(), isHttp);
             Value defaultValue = parameterModel.getDefaultValue();
             defaultValue.setValue(parameter.expression().toString().trim());
             defaultValue.setValueType(ServiceModelGeneratorConstants.VALUE_TYPE_EXPRESSION);
@@ -722,11 +722,18 @@ public final class Utils {
     }
 
     private static Parameter createParameter(String paramName, String paramKind, String valueType, String typeName,
-                                             NodeList<AnnotationNode> annotationNodes) {
+                                             NodeList<AnnotationNode> annotationNodes, boolean isHttp) {
         Parameter parameterModel = Parameter.getNewParameter();
         parameterModel.setMetadata(new MetaData(paramName, paramName));
         parameterModel.setKind(paramKind);
-        getHttpParameterType(annotationNodes).ifPresent(parameterModel::setHttpParamType);
+        if (isHttp) {
+            Optional<String> httpParameterType = getHttpParameterType(annotationNodes);
+            if (httpParameterType.isPresent()) {
+                parameterModel.setHttpParamType(httpParameterType.get());
+            } else {
+                parameterModel.setHttpParamType(ServiceModelGeneratorConstants.HTTP_PARAM_TYPE_QUERY);
+            }
+        }
         Value type = parameterModel.getType();
         type.setValue(typeName);
         type.setValueType(ServiceModelGeneratorConstants.VALUE_TYPE_TYPE);

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/Utils.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/Utils.java
@@ -1240,4 +1240,17 @@ public final class Utils {
         String exprUriString = "expr" + Paths.get(sourcePath).toUri().toString().substring(4);
         return URI.create(exprUriString).toString();
     }
+
+    /**
+     * Check if the `default:httpListener` is attached to the service.
+     *
+     * @param value the Listener value
+     * @return true if the `default:httpListener` is attached, false otherwise
+     */
+    public static boolean isHttpDefaultListenerAttached(Value value) {
+        if (value.getValues().isEmpty()) {
+            return ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_REF.equals(value.getValue().trim());
+        }
+        return value.getValues().contains(ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_REF);
+    }
 }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/response/ListenerDiscoveryResponse.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/response/ListenerDiscoveryResponse.java
@@ -18,10 +18,8 @@
 
 package io.ballerina.servicemodelgenerator.extension.response;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public record ListenerDiscoveryResponse(boolean hasListeners, Set<String> listeners, String errorMsg,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/response/ListenerDiscoveryResponse.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/response/ListenerDiscoveryResponse.java
@@ -20,20 +20,22 @@ package io.ballerina.servicemodelgenerator.extension.response;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
-public record ListenerDiscoveryResponse(boolean hasListeners, List<String> listeners, String errorMsg,
+public record ListenerDiscoveryResponse(boolean hasListeners, Set<String> listeners, String errorMsg,
                                         String stacktrace) {
 
     public ListenerDiscoveryResponse() {
-        this(false, new ArrayList<>(), null, null);
+        this(false, new HashSet<>(), null, null);
     }
 
-    public ListenerDiscoveryResponse(List<String> listeners) {
+    public ListenerDiscoveryResponse(Set<String> listeners) {
         this(!listeners.isEmpty(), listeners, null, null);
     }
 
     public ListenerDiscoveryResponse(Throwable e) {
-        this(false, new ArrayList<>(), e.toString(), Arrays.toString(e.getStackTrace()));
+        this(false, new HashSet<>(), e.toString(), Arrays.toString(e.getStackTrace()));
     }
 }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/ServiceModelAPITests.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/ServiceModelAPITests.java
@@ -80,8 +80,8 @@ public class ServiceModelAPITests {
                 "ballerina", "http");
         CompletableFuture<?> result = serviceEndpoint.request("serviceDesign/getListeners", request);
         ListenerDiscoveryResponse response = (ListenerDiscoveryResponse) result.get();
-        Assert.assertFalse(response.hasListeners());
-        Assert.assertEquals(response.listeners().size(), 0);
+        Assert.assertTrue(response.hasListeners());
+        Assert.assertEquals(response.listeners().size(), 1);
     }
 
     @Test(enabled = false)

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/ServiceModelAPITests.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/ServiceModelAPITests.java
@@ -204,7 +204,7 @@ public class ServiceModelAPITests {
         ServiceModelResponse modelResponse = (ServiceModelResponse) modelResult.get();
         Service service = modelResponse.service();
         Assert.assertTrue(Objects.nonNull(service));
-        service.getListener().setValues(List.of("httpTestListener", "httpsTestListener"));
+        service.getListener().setValues(List.of("default:httpListener", "httpsTestListener"));
         Value designApproach = service.getDesignApproach();
         Value selectedApproach = designApproach.getChoices().getFirst();
         Value basePath = selectedApproach.getProperty("basePath");
@@ -523,7 +523,7 @@ public class ServiceModelAPITests {
         ServiceFromSourceResponse sourceResponse = (ServiceFromSourceResponse) sourceResult.get();
         Service service = sourceResponse.service();
         Assert.assertTrue(Objects.nonNull(service));
-        service.getListener().setValue("newHttpListener");
+        service.getListener().setValues(List.of("newHttpListener", "default:httpListener"));
         service.getBasePath().setValue("/api/v1/test/new");
 
         ServiceModifierRequest updateRequest = new ServiceModifierRequest(filePath.toAbsolutePath().toString(),

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_anonymous_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_anonymous_listener.json
@@ -39,6 +39,10 @@
         "placeholder": "",
         "optional": false,
         "advanced": false,
+        "items": [
+          "default:httpListener",
+          "new http:Listener(port = 8080)"
+        ],
         "codedata": {
           "inListenerInit": false,
           "isBasePath": false,
@@ -371,7 +375,8 @@
             "enabled": true,
             "editable": false,
             "optional": false,
-            "advanced": false
+            "advanced": false,
+            "httpParamType": "QUERY"
           }
         ],
         "schema": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_global_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_global_listener.json
@@ -45,7 +45,10 @@
         "optional": false,
         "advanced": false,
         "items": [
+          "default:globalListener",
+          "default:httpListener",
           "httpListener",
+          "new http:Listener(port = 8080)",
           "githubListener"
         ],
         "codedata": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_multiple_listeners.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_multiple_listeners.json
@@ -44,7 +44,9 @@
         "optional": false,
         "advanced": false,
         "items": [
+          "default:httpListener",
           "httpListener",
+          "new http:Listener(port = 8080)",
           "githubListener"
         ],
         "codedata": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_single_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_single_listener.json
@@ -40,6 +40,7 @@
         "optional": false,
         "advanced": false,
         "items": [
+          "default:httpListener",
           "httpListener",
           "githubListener"
         ],
@@ -375,7 +376,8 @@
             "enabled": true,
             "editable": false,
             "optional": false,
-            "advanced": false
+            "advanced": false,
+            "httpParamType": "QUERY"
           }
         ],
         "schema": {


### PR DESCRIPTION
## Purpose
$subject

Following things were fixed with this PR

- Populate default:httpListener for listener discovery list
- If an anonymous Listener is attached to a service show the anonymous Listener in the Service edit form
- Use the default:httpListener as the first choice among http Listeners
- Update the http parameter type http resources 