### PR TITLE
Fix getting whole range when modifying types

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/TypeTransformer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/utils/TypeTransformer.java
@@ -499,7 +499,7 @@ public class TypeTransformer {
 
             functionBuilder
                     .kind(Function.FunctionKind.FUNCTION)
-                    .accessor(methodSymbol.getName().orElse(""));
+                    .name(methodSymbol.getName().orElse(""));
 
             // return type
             functionTypeSymbol.returnTypeDescriptor().ifPresent(returnType -> {
@@ -556,7 +556,9 @@ public class TypeTransformer {
             // resource path
             // TODO: Need a structured schema for resourcePath
             if (methodSymbol.kind().equals(SymbolKind.RESOURCE_METHOD)) {
-                functionBuilder.name(((ResourceMethodSymbol) methodSymbol).resourcePath().signature());
+                functionBuilder
+                        .name(((ResourceMethodSymbol) methodSymbol).resourcePath().signature())
+                        .accessor(methodSymbol.getName().orElse(""));
             }
 
             functions.add(functionBuilder.build());

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/config/get_service_class3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/config/get_service_class3.json
@@ -103,7 +103,6 @@
         ]
       },
       {
-        "accessor": "updateName",
         "qualifiers": [
           "ISOLATED",
           "REMOTE"
@@ -119,6 +118,7 @@
           }
         ],
         "kind": "REMOTE",
+        "name": "updateName",
         "returnType": "UserProfile",
         "refs": [
           "UserProfile"

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/config/update_record_type1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/config/update_record_type1.json
@@ -94,11 +94,11 @@
         "range": {
           "start": {
             "line": 0,
-            "character": 5
+            "character": 0
           },
           "end": {
-            "line": 0,
-            "character": 13
+            "line": 3,
+            "character": 3
           }
         },
         "newText": "type Employee record {|\nPerson user;\nint id;\n|};\n"

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/config/update_record_type2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/config/update_record_type2.json
@@ -97,11 +97,11 @@
         "range": {
           "start": {
             "line": 0,
-            "character": 5
+            "character": 0
           },
           "end": {
-            "line": 0,
-            "character": 13
+            "line": 3,
+            "character": 3
           }
         },
         "newText": "type Employee record {|\n*Person;\n*User;\nPerson user;\nint id;\n|};\n"

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/config/update_record_type3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types_manager/config/update_record_type3.json
@@ -97,11 +97,11 @@
         "range": {
           "start": {
             "line": 0,
-            "character": 5
+            "character": 0
           },
           "end": {
-            "line": 0,
-            "character": 13
+            "line": 3,
+            "character": 3
           }
         },
         "newText": "type Employee record {|\n*Person;\nPerson user;\nint id = 23;\n|};\n"


### PR DESCRIPTION
* Add a new `createCodeSnippet` method to handle different types of node kinds, replacing the previous logic for generating code snippets.
* Fix not getting the line range for the whole definition node
* Set the `name` property instead of `accessor` for remote function