### PR TITLE
Implement the LS APIs to support function definitions

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ModuleNodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ModuleNodeAnalyzer.java
@@ -35,6 +35,8 @@ import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.flowmodelgenerator.core.model.ModuleInfo;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+import io.ballerina.flowmodelgenerator.core.model.Property;
+import io.ballerina.flowmodelgenerator.core.model.node.FunctionDefinitionBuilder;
 
 import java.util.Optional;
 
@@ -76,7 +78,8 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
         nodeBuilder.properties()
                 .functionName(functionDefinitionNode.functionName().text())
                 .returnType(functionDefinitionNode.functionSignature().returnTypeDesc()
-                        .map(type -> type.type().toSourceCode().strip()).orElse(""));
+                        .map(type -> type.type().toSourceCode().strip()).orElse(""))
+                .nestedProperty();
 
         // Set the function parameters
         SeparatedNodeList<ParameterNode> parameters = functionDefinitionNode.functionSignature().parameters();
@@ -105,7 +108,9 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
             }
             nodeBuilder.properties().parameter(paramType, paramName.map(Token::text).orElse(""));
         }
-
+        nodeBuilder.properties().endNestedProperty(Property.ValueType.REPEATABLE_PROPERTY,
+                FunctionDefinitionBuilder.PARAMETERS_KEY, FunctionDefinitionBuilder.PARAMETERS_LABEL,
+                FunctionDefinitionBuilder.PARAMETERS_DOC, FunctionDefinitionBuilder.getParameterSchema());
         this.node = gson.toJsonTree(nodeBuilder.build());
     }
 

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ModuleNodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ModuleNodeAnalyzer.java
@@ -37,6 +37,7 @@ import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.Property;
 import io.ballerina.flowmodelgenerator.core.model.node.FunctionDefinitionBuilder;
+import io.ballerina.tools.text.LineRange;
 
 import java.util.Optional;
 
@@ -73,6 +74,11 @@ public class ModuleNodeAnalyzer extends NodeVisitor {
     public void visit(FunctionDefinitionNode functionDefinitionNode) {
         NodeBuilder nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.FUNCTION_DEFINITION)
                 .defaultModuleName(this.moduleInfo);
+
+        // Set the line range
+        LineRange functionKeywordLineRange = functionDefinitionNode.functionKeyword().lineRange();
+        nodeBuilder.codedata().lineRange(LineRange.from(functionKeywordLineRange.fileName(),
+                functionKeywordLineRange.startLine(), functionDefinitionNode.functionBody().lineRange().startLine()));
 
         // Set the function name and return type
         nodeBuilder.properties()

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ModuleNodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/ModuleNodeAnalyzer.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.wso2.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import io.ballerina.compiler.syntax.tree.DefaultableParameterNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.ParameterNode;
+import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.RestParameterNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.Token;
+import io.ballerina.flowmodelgenerator.core.model.ModuleInfo;
+import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
+import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+
+import java.util.Optional;
+
+/**
+ * Analyzes the module level functions and generates the flow model.
+ *
+ * @since 2.0.0
+ */
+public class ModuleNodeAnalyzer extends NodeVisitor {
+
+    private final ModuleInfo moduleInfo;
+    private final Gson gson;
+    private JsonElement node;
+
+    public ModuleNodeAnalyzer(ModuleInfo moduleInfo) {
+        this.moduleInfo = moduleInfo;
+        this.gson = new Gson();
+    }
+
+    public Optional<JsonElement> findFunction(ModulePartNode rootNode, String functionName) {
+        for (ModuleMemberDeclarationNode member : rootNode.members()) {
+            if (member.kind() == SyntaxKind.FUNCTION_DEFINITION) {
+                FunctionDefinitionNode functionNode = (FunctionDefinitionNode) member;
+                if (functionNode.functionName().text().equals(functionName)) {
+                    functionNode.accept(this);
+                    return Optional.of(this.node);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void visit(FunctionDefinitionNode functionDefinitionNode) {
+        NodeBuilder nodeBuilder = NodeBuilder.getNodeFromKind(NodeKind.FUNCTION_DEFINITION)
+                .defaultModuleName(this.moduleInfo);
+
+        // Set the function name and return type
+        nodeBuilder.properties()
+                .functionName(functionDefinitionNode.functionName().text())
+                .returnType(functionDefinitionNode.functionSignature().returnTypeDesc()
+                        .map(type -> type.type().toSourceCode().strip()).orElse(""));
+
+        // Set the function parameters
+        SeparatedNodeList<ParameterNode> parameters = functionDefinitionNode.functionSignature().parameters();
+        for (ParameterNode parameter : parameters) {
+            String paramType;
+            Optional<Token> paramName;
+            switch (parameter.kind()) {
+                case REQUIRED_PARAM -> {
+                    RequiredParameterNode requiredParameter = (RequiredParameterNode) parameter;
+                    paramType = getNodeValue(requiredParameter.typeName());
+                    paramName = requiredParameter.paramName();
+                }
+                case DEFAULTABLE_PARAM -> {
+                    DefaultableParameterNode defaultableParameter = (DefaultableParameterNode) parameter;
+                    paramType = getNodeValue(defaultableParameter.typeName());
+                    paramName = defaultableParameter.paramName();
+                }
+                case REST_PARAM -> {
+                    RestParameterNode restParameter = (RestParameterNode) parameter;
+                    paramType = getNodeValue(restParameter.typeName()) + restParameter.ellipsisToken().text();
+                    paramName = restParameter.paramName();
+                }
+                default -> {
+                    continue;
+                }
+            }
+            nodeBuilder.properties().parameter(paramType, paramName.map(Token::text).orElse(""));
+        }
+
+        this.node = gson.toJsonTree(nodeBuilder.build());
+    }
+
+    private static String getNodeValue(Node node) {
+        return node.toSourceCode().strip();
+    }
+
+    public JsonElement getNode() {
+        return this.node;
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -666,7 +666,7 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
                     .description(FunctionDefinitionBuilder.FUNCTION_NAME_DOC)
                     .stepOut()
                 .type(Property.ValueType.IDENTIFIER)
-                .value(functionName)
+                .value(functionName == null ? "" : functionName)
                 .editable();
 
         addProperty(Property.FUNCTION_NAME_KEY);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -41,6 +41,7 @@ import io.ballerina.flowmodelgenerator.core.utils.CommonUtils;
 import io.ballerina.flowmodelgenerator.core.utils.ParamUtils;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.langserver.common.utils.NameUtil;
+import org.ballerinalang.model.types.TypeKind;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -801,6 +802,36 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
                 .editable();
         addProperty(WaitBuilder.WAIT_ALL_KEY);
         return this;
+    }
+
+    public FormBuilder<T> parameter(String type, String name) {
+        nestedProperty();
+
+        // Build the parameter type property
+        propertyBuilder
+                .metadata()
+                    .label(Property.TYPE_LABEL)
+                    .description(Property.TYPE_DOC)
+                    .stepOut()
+                .type(Property.ValueType.TYPE)
+                .typeConstraint(TypeKind.ANYDATA.typeName())
+                .value(type)
+                .editable();
+        addProperty(Property.TYPE_KEY);
+
+        // Build the parameter name property
+        propertyBuilder
+                .metadata()
+                    .label(Property.VARIABLE_NAME)
+                    .description(Property.VARIABLE_DOC)
+                    .stepOut()
+                .type(Property.ValueType.IDENTIFIER)
+                .value(name)
+                .editable();
+        addProperty(Property.VARIABLE_KEY);
+
+        return endNestedProperty(Property.ValueType.FIXED_PROPERTY, name, Property.PARAMETER_LABEL,
+                Property.PARAMETER_DOC);
     }
 
     public FormBuilder<T> nestedProperty() {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.flowmodelgenerator.core.model;
 
+import com.google.gson.reflect.TypeToken;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
@@ -44,6 +45,7 @@ import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.langserver.common.utils.NameUtil;
 import org.ballerinalang.model.types.TypeKind;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -73,11 +75,12 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
 
     private Map<String, Property> nodeProperties;
     private final Stack<Map<String, Property>> nodePropertiesStack;
-
     private final SemanticModel semanticModel;
     private final DiagnosticHandler diagnosticHandler;
     protected Property.Builder<FormBuilder<T>> propertyBuilder;
     private final ModuleInfo moduleInfo;
+
+    public static final Type NODE_PROPERTIES_TYPE =  new TypeToken<Map<String, Property>>() { }.getType();
 
     public FormBuilder(SemanticModel semanticModel, DiagnosticHandler diagnosticHandler,
                        ModuleInfo moduleInfo, T parentBuilder) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -35,6 +35,7 @@ import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.flowmodelgenerator.core.DiagnosticHandler;
 import io.ballerina.flowmodelgenerator.core.model.node.DataMapperBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ExpressionBuilder;
+import io.ballerina.flowmodelgenerator.core.model.node.FunctionDefinitionBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.RemoteActionCallBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.WaitBuilder;
 import io.ballerina.flowmodelgenerator.core.utils.CommonUtils;
@@ -55,9 +56,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.Stack;
 
-import static io.ballerina.flowmodelgenerator.core.model.node.DataMapperBuilder.FUNCTION_NAME_DOC;
-import static io.ballerina.flowmodelgenerator.core.model.node.DataMapperBuilder.FUNCTION_NAME_KEY;
-import static io.ballerina.flowmodelgenerator.core.model.node.DataMapperBuilder.FUNCTION_NAME_LABEL;
 import static io.ballerina.flowmodelgenerator.core.model.node.DataMapperBuilder.INPUTS_DOC;
 import static io.ballerina.flowmodelgenerator.core.model.node.DataMapperBuilder.INPUTS_KEY;
 import static io.ballerina.flowmodelgenerator.core.model.node.DataMapperBuilder.INPUTS_LABEL;
@@ -664,14 +662,14 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
     public FormBuilder<T> functionName(String functionName) {
         propertyBuilder
                 .metadata()
-                    .label(FUNCTION_NAME_LABEL)
-                    .description(FUNCTION_NAME_DOC)
+                    .label(FunctionDefinitionBuilder.FUNCTION_NAME_LABEL)
+                    .description(FunctionDefinitionBuilder.FUNCTION_NAME_DOC)
                     .stepOut()
                 .type(Property.ValueType.IDENTIFIER)
                 .value(functionName)
                 .editable();
 
-        addProperty(FUNCTION_NAME_KEY);
+        addProperty(Property.FUNCTION_NAME_KEY);
         return this;
     }
 

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -810,21 +810,25 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
         return this;
     }
 
-    public FormBuilder<T> endNestedProperty(Property.ValueType valueType, String key, String label, String doc) {
-        if (!nodeProperties.isEmpty()) {
-            propertyBuilder
-                    .metadata()
-                        .label(label)
-                        .description(doc)
-                        .stepOut()
-                    .value(nodeProperties)
-                    .type(valueType);
-            if (!nodePropertiesStack.isEmpty()) {
-                nodeProperties = nodePropertiesStack.pop();
-            }
-            addProperty(key);
+    public FormBuilder<T> endNestedProperty(Property.ValueType valueType, String key, String label, String doc,
+                                            Object typeConstraint) {
+        propertyBuilder
+                .metadata()
+                    .label(label)
+                    .description(doc)
+                    .stepOut()
+                .value(nodeProperties)
+                .typeConstraint(typeConstraint)
+                .type(valueType);
+        if (!nodePropertiesStack.isEmpty()) {
+            nodeProperties = nodePropertiesStack.pop();
         }
+        addProperty(key);
         return this;
+    }
+
+    public FormBuilder<T> endNestedProperty(Property.ValueType valueType, String key, String label, String doc) {
+        return endNestedProperty(valueType, key, label, doc, null);
     }
 
     public final void addProperty(String key, Node node) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeBuilder.java
@@ -39,6 +39,7 @@ import io.ballerina.flowmodelgenerator.core.model.node.FailBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ForeachBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.ForkBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.FunctionCall;
+import io.ballerina.flowmodelgenerator.core.model.node.FunctionDefinitionBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.IfBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.JsonPayloadBuilder;
 import io.ballerina.flowmodelgenerator.core.model.node.LockBuilder;
@@ -124,6 +125,7 @@ public abstract class NodeBuilder implements DiagnosticHandler.DiagnosticCapable
         put(NodeKind.METHOD_CALL, MethodCall::new);
         put(NodeKind.FOREACH, ForeachBuilder::new);
         put(NodeKind.DATA_MAPPER, DataMapperBuilder::new);
+        put(NodeKind.FUNCTION_DEFINITION, FunctionDefinitionBuilder::new);
         put(NodeKind.VARIABLE, VariableBuilder::new);
         put(NodeKind.ASSIGN, AssignBuilder::new);
         put(NodeKind.COMMENT, CommentBuilder::new);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeKind.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/NodeKind.java
@@ -38,6 +38,7 @@ public enum NodeKind {
     STOP,
     FOREACH,
     DATA_MAPPER,
+    FUNCTION_DEFINITION,
     COMMENT,
     MATCH,
     FUNCTION,

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -157,6 +157,9 @@ public record Property(Metadata metadata, String valueType, Object valueTypeCons
     public static final String DEFAULT_VALUE_DOC = "Default value for the config, if empty your need to " +
             "provide a value at runtime";
 
+    public static final String PARAMETER_LABEL = "Parameter";
+    public static final String PARAMETER_DOC = "Function parameter";
+
     public String toSourceCode() {
         if (value == null || value.toString().isEmpty()) {
             return placeholder == null ? "" : placeholder;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -90,7 +90,7 @@ public record Property(Metadata metadata, String valueType, Object valueTypeCons
     public static final String TYPE_QUALIFIERS_DOC = "Qualifiers of the type";
 
     public static final String RETURN_TYPE_LABEL = "Return Type";
-    public static final String RETURN_TYPE_DOC = "Return type of the function/worker";
+    public static final String RETURN_TYPE_DOC = "Type of the return value";
 
     public static final String EXPRESSION_KEY = "expression";
     public static final String EXPRESSION_LABEL = "Expression";
@@ -159,6 +159,8 @@ public record Property(Metadata metadata, String valueType, Object valueTypeCons
 
     public static final String PARAMETER_LABEL = "Parameter";
     public static final String PARAMETER_DOC = "Function parameter";
+
+    public static final String FUNCTION_NAME_KEY = "functionName";
 
     public String toSourceCode() {
         if (value == null || value.toString().isEmpty()) {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
@@ -18,15 +18,14 @@
 
 package io.ballerina.flowmodelgenerator.core.model.node;
 
+import io.ballerina.flowmodelgenerator.core.model.FormBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.Property;
 import io.ballerina.flowmodelgenerator.core.model.SourceBuilder;
-import org.ballerinalang.model.types.TypeKind;
 import org.eclipse.lsp4j.TextEdit;
 
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,9 +42,6 @@ public class FunctionDefinitionBuilder extends NodeBuilder {
     public static final String PARAMETERS_KEY = "parameters";
     public static final String PARAMETERS_LABEL = "Parameters";
     public static final String PARAMETERS_DOC = "Function parameters";
-
-    public static final String PARAMETER_LABEL = "Parameter";
-    public static final String PARAMETER_DOC = "Function parameter";
 
     @Override
     public void setConcreteConstData() {
@@ -73,49 +69,10 @@ public class FunctionDefinitionBuilder extends NodeBuilder {
         private static final Property PARAMETER_SCHEMA = initParameterSchema();
 
         private static Property initParameterSchema() {
-            Property.Builder<?> propertyBuilder = new Property.Builder<>(null);
-
-            // Build the type property
-            propertyBuilder
-                    .metadata()
-                        .label(Property.TYPE_LABEL)
-                        .description(Property.TYPE_DOC)
-                        .stepOut()
-                    .type(Property.ValueType.TYPE)
-                    .typeConstraint(TypeKind.ANYDATA.typeName())
-                    .value("")
-                    .editable();
-            Property typeProperty = propertyBuilder.build();
-
-            // Build the data property
-            propertyBuilder = new Property.Builder<>(null);
-            propertyBuilder
-                    .metadata()
-                        .label(Property.VARIABLE_NAME)
-                        .description(Property.VARIABLE_DOC)
-                        .stepOut()
-                    .type(Property.ValueType.IDENTIFIER)
-                    .value("")
-                    .editable();
-            Property dataProperty = propertyBuilder.build();
-
-            // Build the node properties
-            Map<String, Property> nodeProperties = new HashMap<>();
-            nodeProperties.put(Property.TYPE_KEY, typeProperty);
-            nodeProperties.put(Property.VARIABLE_KEY, dataProperty);
-
-            // Build the property schema
-            propertyBuilder = new Property.Builder<>(null);
-            propertyBuilder
-                    .metadata()
-                        .label(PARAMETER_LABEL)
-                        .description(PARAMETER_DOC)
-                        .stepOut()
-                    .type(Property.ValueType.FIXED_PROPERTY)
-                    .editable()
-                    .value(nodeProperties);
-
-            return propertyBuilder.build();
+            FormBuilder<?> formBuilder = new FormBuilder<>(null, null, null, null);
+            formBuilder.parameter("", "");
+            Map<String, Property> nodeProperties = formBuilder.build();
+            return nodeProperties.get("");
         }
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.flowmodelgenerator.core.model.node;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.flowmodelgenerator.core.model.FormBuilder;
@@ -99,7 +98,7 @@ public class FunctionDefinitionBuilder extends NodeBuilder {
                     continue;
                 }
                 Map<String, Property> paramProperties = gson.fromJson(gson.toJsonTree(paramData),
-                        new TypeToken<Map<String, Property>>() { }.getType());
+                        FormBuilder.NODE_PROPERTIES_TYPE);
 
                 String paramType = paramProperties.get(Property.TYPE_KEY).value().toString();
                 String paramName = paramProperties.get(Property.VARIABLE_KEY).value().toString();

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.model.node;
+
+import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
+import io.ballerina.flowmodelgenerator.core.model.NodeKind;
+import io.ballerina.flowmodelgenerator.core.model.Property;
+import io.ballerina.flowmodelgenerator.core.model.SourceBuilder;
+import org.ballerinalang.model.types.TypeKind;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents the properties of a function definition node.
+ *
+ * @since 2.0.0
+ */
+public class FunctionDefinitionBuilder extends NodeBuilder {
+
+    public static final String LABEL = "Function Definition";
+    public static final String DESCRIPTION = "Define a function";
+
+    public static final String PARAMETERS_KEY = "parameters";
+    public static final String PARAMETERS_LABEL = "Parameters";
+    public static final String PARAMETERS_DOC = "Function parameters";
+
+    public static final String PARAMETER_LABEL = "Parameter";
+    public static final String PARAMETER_DOC = "Function parameter";
+
+    private static Property parameterSchema;
+
+    private static Property getParameterSchema() {
+        if (parameterSchema != null) {
+            return parameterSchema;
+        }
+        Property.Builder<?> propertyBuilder = new Property.Builder<>(null);
+
+        // Build the type property
+        propertyBuilder
+                .metadata()
+                    .label(Property.TYPE_LABEL)
+                    .description(Property.TYPE_DOC)
+                    .stepOut()
+                .type(Property.ValueType.TYPE)
+                .typeConstraint(TypeKind.ANYDATA.typeName())
+                .value("")
+                .editable();
+        Property typeProperty = propertyBuilder.build();
+
+        // Build the data property
+        propertyBuilder = new Property.Builder<>(null);
+        propertyBuilder
+                .metadata()
+                    .label(Property.VARIABLE_NAME)
+                    .description(Property.VARIABLE_DOC)
+                    .stepOut()
+                .type(Property.ValueType.IDENTIFIER)
+                .value("")
+                .editable();
+        Property dataProperty = propertyBuilder.build();
+
+        // Build the node properties
+        Map<String, Property> nodeProperties = new HashMap<>();
+        nodeProperties.put(Property.TYPE_KEY, typeProperty);
+        nodeProperties.put(Property.VARIABLE_KEY, dataProperty);
+
+        // Build the property schema
+        propertyBuilder = new Property.Builder<>(null);
+        propertyBuilder
+                .metadata()
+                    .label(PARAMETER_LABEL)
+                    .description(PARAMETER_DOC)
+                    .stepOut()
+                .type(Property.ValueType.FIXED_PROPERTY)
+                .editable()
+                .value(nodeProperties);
+
+        parameterSchema = propertyBuilder.build();
+        return parameterSchema;
+    }
+
+    @Override
+    public void setConcreteConstData() {
+        metadata().label(LABEL).description(DESCRIPTION);
+        codedata().node(NodeKind.FUNCTION_DEFINITION);
+    }
+
+    @Override
+    public void setConcreteTemplateData(TemplateContext context) {
+        properties()
+                .functionName(null)
+                .returnType(null)
+                .nestedProperty()
+                .endNestedProperty(Property.ValueType.REPEATABLE_PROPERTY, PARAMETERS_KEY,
+                        PARAMETERS_LABEL, PARAMETERS_DOC, getParameterSchema());
+    }
+
+    @Override
+    public Map<Path, List<TextEdit>> toSource(SourceBuilder sourceBuilder) {
+        return null;
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
@@ -47,58 +47,6 @@ public class FunctionDefinitionBuilder extends NodeBuilder {
     public static final String PARAMETER_LABEL = "Parameter";
     public static final String PARAMETER_DOC = "Function parameter";
 
-    private static Property parameterSchema;
-
-    private static Property getParameterSchema() {
-        if (parameterSchema != null) {
-            return parameterSchema;
-        }
-        Property.Builder<?> propertyBuilder = new Property.Builder<>(null);
-
-        // Build the type property
-        propertyBuilder
-                .metadata()
-                    .label(Property.TYPE_LABEL)
-                    .description(Property.TYPE_DOC)
-                    .stepOut()
-                .type(Property.ValueType.TYPE)
-                .typeConstraint(TypeKind.ANYDATA.typeName())
-                .value("")
-                .editable();
-        Property typeProperty = propertyBuilder.build();
-
-        // Build the data property
-        propertyBuilder = new Property.Builder<>(null);
-        propertyBuilder
-                .metadata()
-                    .label(Property.VARIABLE_NAME)
-                    .description(Property.VARIABLE_DOC)
-                    .stepOut()
-                .type(Property.ValueType.IDENTIFIER)
-                .value("")
-                .editable();
-        Property dataProperty = propertyBuilder.build();
-
-        // Build the node properties
-        Map<String, Property> nodeProperties = new HashMap<>();
-        nodeProperties.put(Property.TYPE_KEY, typeProperty);
-        nodeProperties.put(Property.VARIABLE_KEY, dataProperty);
-
-        // Build the property schema
-        propertyBuilder = new Property.Builder<>(null);
-        propertyBuilder
-                .metadata()
-                    .label(PARAMETER_LABEL)
-                    .description(PARAMETER_DOC)
-                    .stepOut()
-                .type(Property.ValueType.FIXED_PROPERTY)
-                .editable()
-                .value(nodeProperties);
-
-        parameterSchema = propertyBuilder.build();
-        return parameterSchema;
-    }
-
     @Override
     public void setConcreteConstData() {
         metadata().label(LABEL).description(DESCRIPTION);
@@ -112,11 +60,62 @@ public class FunctionDefinitionBuilder extends NodeBuilder {
                 .returnType(null)
                 .nestedProperty()
                 .endNestedProperty(Property.ValueType.REPEATABLE_PROPERTY, PARAMETERS_KEY,
-                        PARAMETERS_LABEL, PARAMETERS_DOC, getParameterSchema());
+                        PARAMETERS_LABEL, PARAMETERS_DOC, ParameterSchemaHolder.PARAMETER_SCHEMA);
     }
 
     @Override
     public Map<Path, List<TextEdit>> toSource(SourceBuilder sourceBuilder) {
         return null;
+    }
+
+    private static class ParameterSchemaHolder {
+
+        private static final Property PARAMETER_SCHEMA = initParameterSchema();
+
+        private static Property initParameterSchema() {
+            Property.Builder<?> propertyBuilder = new Property.Builder<>(null);
+
+            // Build the type property
+            propertyBuilder
+                    .metadata()
+                        .label(Property.TYPE_LABEL)
+                        .description(Property.TYPE_DOC)
+                        .stepOut()
+                    .type(Property.ValueType.TYPE)
+                    .typeConstraint(TypeKind.ANYDATA.typeName())
+                    .value("")
+                    .editable();
+            Property typeProperty = propertyBuilder.build();
+
+            // Build the data property
+            propertyBuilder = new Property.Builder<>(null);
+            propertyBuilder
+                    .metadata()
+                        .label(Property.VARIABLE_NAME)
+                        .description(Property.VARIABLE_DOC)
+                        .stepOut()
+                    .type(Property.ValueType.IDENTIFIER)
+                    .value("")
+                    .editable();
+            Property dataProperty = propertyBuilder.build();
+
+            // Build the node properties
+            Map<String, Property> nodeProperties = new HashMap<>();
+            nodeProperties.put(Property.TYPE_KEY, typeProperty);
+            nodeProperties.put(Property.VARIABLE_KEY, dataProperty);
+
+            // Build the property schema
+            propertyBuilder = new Property.Builder<>(null);
+            propertyBuilder
+                    .metadata()
+                        .label(PARAMETER_LABEL)
+                        .description(PARAMETER_DOC)
+                        .stepOut()
+                    .type(Property.ValueType.FIXED_PROPERTY)
+                    .editable()
+                    .value(nodeProperties);
+
+            return propertyBuilder.build();
+        }
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
@@ -39,9 +39,16 @@ public class FunctionDefinitionBuilder extends NodeBuilder {
     public static final String LABEL = "Function Definition";
     public static final String DESCRIPTION = "Define a function";
 
+    public static final String FUNCTION_NAME_LABEL = "Function Name";
+    public static final String FUNCTION_NAME_DOC = "Name of the function";
+
     public static final String PARAMETERS_KEY = "parameters";
     public static final String PARAMETERS_LABEL = "Parameters";
     public static final String PARAMETERS_DOC = "Function parameters";
+
+    public static Property getParameterSchema() {
+        return ParameterSchemaHolder.PARAMETER_SCHEMA;
+    }
 
     @Override
     public void setConcreteConstData() {
@@ -55,8 +62,8 @@ public class FunctionDefinitionBuilder extends NodeBuilder {
                 .functionName(null)
                 .returnType(null)
                 .nestedProperty()
-                .endNestedProperty(Property.ValueType.REPEATABLE_PROPERTY, PARAMETERS_KEY,
-                        PARAMETERS_LABEL, PARAMETERS_DOC, ParameterSchemaHolder.PARAMETER_SCHEMA);
+                .endNestedProperty(Property.ValueType.REPEATABLE_PROPERTY, PARAMETERS_KEY, PARAMETERS_LABEL,
+                        PARAMETERS_DOC, getParameterSchema());
     }
 
     @Override

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WaitBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WaitBuilder.java
@@ -21,12 +21,14 @@ package io.ballerina.flowmodelgenerator.core.model.node;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.flowmodelgenerator.core.model.FormBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.Property;
 import io.ballerina.flowmodelgenerator.core.model.SourceBuilder;
 import org.eclipse.lsp4j.TextEdit;
 
+import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -102,7 +104,7 @@ public class WaitBuilder extends NodeBuilder {
             }
 
             Map<String, Property> futureChildProperties = gson.fromJson(gson.toJsonTree(futureChildMap),
-                    new TypeToken<Map<String, Property>>() { }.getType());
+                    FormBuilder.NODE_PROPERTIES_TYPE);
 
             String waitField;
             Property variableProperty = futureChildProperties.get(Property.VARIABLE_KEY);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WaitBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/WaitBuilder.java
@@ -19,7 +19,6 @@
 package io.ballerina.flowmodelgenerator.core.model.node;
 
 import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.flowmodelgenerator.core.model.FormBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
@@ -28,7 +27,6 @@ import io.ballerina.flowmodelgenerator.core.model.Property;
 import io.ballerina.flowmodelgenerator.core.model.SourceBuilder;
 import org.eclipse.lsp4j.TextEdit;
 
-import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/FlowModelGeneratorService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/FlowModelGeneratorService.java
@@ -68,6 +68,7 @@ import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectKind;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
 import io.ballerina.tools.text.TextDocument;
@@ -501,10 +502,12 @@ public class FlowModelGeneratorService implements ExtendedLanguageServerService 
             try {
                 // Load the project
                 Path projectPath = Path.of(request.projectPath());
-                this.workspaceManager.loadProject(projectPath);
+                Project project = this.workspaceManager.loadProject(projectPath);
 
                 // Find the document containing the function definition
-                Optional<Document> optDocument = this.workspaceManager.document(projectPath);
+                Path documentPath = project.kind() == ProjectKind.SINGLE_FILE_PROJECT ? projectPath :
+                        projectPath.resolve(request.fileName());
+                Optional<Document> optDocument = this.workspaceManager.document(documentPath);
                 if (optDocument.isEmpty()) {
                     return response;
                 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/FunctionDefinitionRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/FunctionDefinitionRequest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension.request;
+
+/**
+ * Represents the request for getting a function definition.
+ *
+ * @param projectPath  path to the project
+ * @param fileName     name of the file containing the function
+ * @param functionName name of the function to retrieve
+ * @since 2.0.0
+ */
+public record FunctionDefinitionRequest(String projectPath, String fileName, String functionName) {
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/response/FunctionDefinitionResponse.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/response/FunctionDefinitionResponse.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension.response;
+
+import com.google.gson.JsonElement;
+
+/**
+ * Represents the response for the function definition API.
+ *
+ * @since 1.4.0
+ */
+public class FunctionDefinitionResponse extends AbstractFlowModelResponse {
+
+    private JsonElement functionDefinition;
+
+    public void setFunctionDefinition(JsonElement functionDefinition) {
+        this.functionDefinition = functionDefinition;
+    }
+
+    public JsonElement getFunctionDefinition() {
+        return functionDefinition;
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionDefinitionTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionDefinitionTest.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension;
+
+import com.google.gson.JsonObject;
+import io.ballerina.flowmodelgenerator.extension.request.FunctionDefinitionRequest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Test cases for the function definition request.
+ *
+ * @since 2.0.0
+ */
+public class FunctionDefinitionTest extends AbstractLSTest {
+
+    @Override
+    @Test(dataProvider = "data-provider")
+    public void test(Path config) throws IOException {
+        Path configJsonPath = configDir.resolve(config);
+        TestConfig testConfig = gson.fromJson(Files.newBufferedReader(configJsonPath), TestConfig.class);
+        FunctionDefinitionRequest request = new FunctionDefinitionRequest(
+                getSourcePath(testConfig.filePath()),
+                testConfig.fileName(),
+                testConfig.functionName());
+        JsonObject functionDefinition = getResponseAndCloseFile(request, testConfig.filePath())
+                .getAsJsonObject("functionDefinition");
+
+        if (!functionDefinition.equals(testConfig.output())) {
+            TestConfig updatedConfig = new TestConfig(
+                    testConfig.filePath(),
+                    testConfig.fileName(),
+                    testConfig.functionName(),
+                    testConfig.description(),
+                    functionDefinition);
+            updateConfig(configJsonPath, updatedConfig);
+            compareJsonElements(functionDefinition, testConfig.output());
+            Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
+        }
+    }
+
+    @Override
+    protected String getResourceDir() {
+        return "function_definition";
+    }
+
+    @Override
+    protected Class<? extends AbstractLSTest> clazz() {
+        return FunctionDefinitionTest.class;
+    }
+
+    @Override
+    protected String getApiName() {
+        return "functionDefinition";
+    }
+
+    private record TestConfig(String filePath, String fileName, String functionName, String description,
+                              JsonObject output) {
+
+        public String description() {
+            return description == null ? "" : description;
+        }
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionDefinitionTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionDefinitionTest.java
@@ -53,7 +53,7 @@ public class FunctionDefinitionTest extends AbstractLSTest {
                     testConfig.functionName(),
                     testConfig.description(),
                     functionDefinition);
-            updateConfig(configJsonPath, updatedConfig);
+//            updateConfig(configJsonPath, updatedConfig);
             compareJsonElements(functionDefinition, testConfig.output());
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork1.json
@@ -92,7 +92,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -175,7 +175,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -258,7 +258,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork2.json
@@ -92,7 +92,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -175,7 +175,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -283,7 +283,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork3.json
@@ -152,7 +152,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",
@@ -322,7 +322,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork4.json
@@ -152,7 +152,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",
@@ -322,7 +322,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",
@@ -530,7 +530,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork5.json
@@ -212,7 +212,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string",
@@ -320,7 +320,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",
@@ -416,7 +416,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork6.json
@@ -211,7 +211,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",
@@ -307,7 +307,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "",
@@ -429,7 +429,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait3.json
@@ -91,7 +91,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -220,7 +220,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait4.json
@@ -91,7 +91,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -220,7 +220,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -349,7 +349,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait5.json
@@ -91,7 +91,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -220,7 +220,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -349,7 +349,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait6.json
@@ -91,7 +91,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -220,7 +220,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -349,7 +349,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait7.json
@@ -91,7 +91,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "int",
@@ -222,7 +222,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string",
@@ -353,7 +353,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "boolean",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait8.json
@@ -91,7 +91,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",
@@ -220,7 +220,7 @@
               "type": {
                 "metadata": {
                   "label": "Return Type",
-                  "description": "Return type of the function/worker"
+                  "description": "Type of the return value"
                 },
                 "valueType": "TYPE",
                 "value": "string|error",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/config1.json
@@ -1,0 +1,124 @@
+{
+  "filePath": "proj",
+  "fileName": "main.bal",
+  "functionName": "main",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "main",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "name": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "name",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/config1.json
@@ -4,13 +4,24 @@
   "functionName": "main",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "33979",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "main.bal",
+        "startLine": {
+          "line": 2,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 2,
+          "offset": 34
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/config2.json
@@ -1,0 +1,159 @@
+{
+  "filePath": "proj",
+  "fileName": "functions.bal",
+  "functionName": "foo",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "foo",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "foo": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "foo",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "bar": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int...",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "bar",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/config2.json
@@ -4,13 +4,24 @@
   "functionName": "foo",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "31796",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "functions.bal",
+        "startLine": {
+          "line": 0,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 0,
+          "offset": 52
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single1.json
@@ -4,13 +4,24 @@
   "functionName": "simpleFunction",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "32986",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 33
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single1.json
@@ -1,0 +1,88 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "simpleFunction",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "simpleFunction",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single10.json
@@ -1,0 +1,99 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "'from",
+  "description": "",
+  "output": {
+    "id": "83569",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 52,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 52,
+          "offset": 24
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "'from",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single11.json
@@ -1,0 +1,99 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "ව",
+  "description": "",
+  "output": {
+    "id": "89517",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 58,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 58,
+          "offset": 20
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "ව",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single2.json
@@ -4,13 +4,24 @@
   "functionName": "add",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "37959",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 6,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 6,
+          "offset": 46
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single2.json
@@ -1,0 +1,159 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "add",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "add",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "int",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "a": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "a",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "b": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "b",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single3.json
@@ -1,0 +1,159 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "greet",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "greet",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "name": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "name",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "title": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "title",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single3.json
@@ -4,13 +4,24 @@
   "functionName": "greet",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "42945",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 11,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 11,
+          "offset": 72
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single4.json
@@ -1,0 +1,124 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "sum",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "sum",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "int",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "numbers": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int...",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "numbers",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single4.json
@@ -4,13 +4,24 @@
   "functionName": "sum",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "47881",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 16,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 16,
+          "offset": 48
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single5.json
@@ -1,0 +1,229 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "complexFunction",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "complexFunction",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "required": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "required",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "name": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "name",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "flag": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "boolean",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "flag",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "rest": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int...",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "rest",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single5.json
@@ -4,13 +4,24 @@
   "functionName": "complexFunction",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "56882",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 25,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 25,
+          "offset": 121
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single6.json
@@ -1,0 +1,159 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "divide",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "divide",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "int|error",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "a": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "a",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "b": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "b",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single6.json
@@ -4,13 +4,24 @@
   "functionName": "divide",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "65744",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 34,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 34,
+          "offset": 55
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single7.json
@@ -4,13 +4,24 @@
   "functionName": "getCounter",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "73730",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 42,
+          "offset": 9
+        },
+        "endLine": {
+          "line": 42,
+          "offset": 43
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single7.json
@@ -1,0 +1,88 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "getCounter",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "getCounter",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "int",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single8.json
@@ -1,0 +1,124 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "processUser",
+  "description": "",
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "processUser",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "user": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "record {|string name; int age;|}",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "user",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single8.json
@@ -4,13 +4,24 @@
   "functionName": "processUser",
   "description": "",
   "output": {
-    "id": "31",
+    "id": "78667",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 47,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 47,
+          "offset": 82
+        }
+      }
     },
     "returning": false,
     "properties": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/single9.json
@@ -1,0 +1,99 @@
+{
+  "filePath": "single.bal",
+  "fileName": "single.bal",
+  "functionName": "\\$dollar\\#hash",
+  "description": "",
+  "output": {
+    "id": "86554",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 55,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 55,
+          "offset": 33
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "\\$dollar\\#hash",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/proj/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/proj/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "nipunaf"
+name = "proj"
+version = "0.1.0"
+distribution = "2201.11.0-20241209-162400-0c015833"
+
+[build-options]
+observabilityIncluded = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/proj/functions.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/proj/functions.bal
@@ -1,0 +1,3 @@
+function foo(string foo, int... bar) returns string {
+    return string `Required: ${foo}, Rest: `;
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/proj/main.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/proj/main.bal
@@ -1,0 +1,5 @@
+import ballerina/io;
+
+public function main(string name) {
+    io:println(string `Hello ${name}!`);
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/single.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/single.bal
@@ -48,3 +48,13 @@ isolated function getCounter() returns int {
 public function processUser(record {|string name; int age;|} user) returns string {
     return string `${user.name} is ${user.age} years old`;
 }
+
+// Function name with special characters
+public function 'from() {
+}
+
+public function \$dollar\#hash() {
+}
+
+public function ව() {
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/single.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/source/single.bal
@@ -1,0 +1,50 @@
+// Basic function with no parameters and no return value
+public function simpleFunction() {
+    // Function body
+}
+
+// Function with parameters and return type
+public function add(int a, int b) returns int {
+    return a + b;
+}
+
+// Function with optional parameters
+public function greet(string name, string title = "Mr.") returns string {
+    return string `Hello ${title} ${name}!`;
+}
+
+// Function with rest parameters
+public function sum(int... numbers) returns int {
+    int total = 0;
+    foreach int num in numbers {
+        total += num;
+    }
+    return total;
+}
+
+// Function with all 
+public function complexFunction(int required, string name = "default", boolean flag = false, int... rest) returns string {
+    string result = string `Required: ${required}, Name: ${name}, Flag: ${flag}, Rest: `;
+    foreach int num in rest {
+        result += num.toString() + " ";
+    }
+    return result;
+}
+
+// Function with default return value
+public function divide(int a, int b) returns int|error {
+    if b == 0 {
+        return error("Division by zero");
+    }
+    return a / b;
+}
+
+// Isolated function
+isolated function getCounter() returns int {
+    return 42;
+}
+
+// Function with record type parameter
+public function processUser(record {|string name; int age;|} user) returns string {
+    return string `${user.name} is ${user.age} years old`;
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/fork.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/fork.json
@@ -26,7 +26,7 @@
           "type": {
             "metadata": {
               "label": "Return Type",
-              "description": "Return type of the function/worker"
+              "description": "Type of the return value"
             },
             "valueType": "TYPE",
             "value": "",
@@ -59,7 +59,7 @@
           "type": {
             "metadata": {
               "label": "Return Type",
-              "description": "Return type of the function/worker"
+              "description": "Type of the return value"
             },
             "valueType": "TYPE",
             "value": "",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_definition.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_definition.json
@@ -1,0 +1,87 @@
+{
+  "description": "Sample diagram node",
+  "codedata": {
+    "node": "FUNCTION_DEFINITION"
+  },
+  "output": {
+    "id": "31",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Data mapper name",
+          "description": "Name of the data mapper function"
+        },
+        "valueType": "IDENTIFIER",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Return type of the function/worker"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": true,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/parallel_flow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/parallel_flow.json
@@ -26,7 +26,7 @@
           "type": {
             "metadata": {
               "label": "Return Type",
-              "description": "Return type of the function/worker"
+              "description": "Type of the return value"
             },
             "valueType": "TYPE",
             "value": "",
@@ -59,7 +59,7 @@
           "type": {
             "metadata": {
               "label": "Return Type",
-              "description": "Return type of the function/worker"
+              "description": "Type of the return value"
             },
             "valueType": "TYPE",
             "value": "",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/testng.xml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/testng.xml
@@ -54,6 +54,7 @@ under the License.
             <class name="io.ballerina.flowmodelgenerator.extension.DataMappingAddElementTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.OpenApiClientGeneratorTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.JsonConverterTest"/>
+            <class name="io.ballerina.flowmodelgenerator.extension.FunctionDefinitionTest"/>
             <!--types manager-->
             <class name="io.ballerina.flowmodelgenerator.extension.typesmanager.GetAllTypesTest"/>
             <class name="io.ballerina.flowmodelgenerator.extension.typesmanager.GetTypeTest"/>

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition.json
@@ -1,9 +1,7 @@
 {
+  "source": "function_definition/main.bal",
   "description": "Sample diagram node",
-  "codedata": {
-    "node": "FUNCTION_DEFINITION"
-  },
-  "output": {
+  "diagram": {
     "id": "31",
     "metadata": {
       "label": "Function Definition",
@@ -20,7 +18,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
-        "value": "",
+        "value": "fn",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -84,5 +82,22 @@
       }
     },
     "flags": 0
+  },
+  "output": {
+    "function_definition/functions.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 1
+          },
+          "end": {
+            "line": 3,
+            "character": 1
+          }
+        },
+        "newText": "function fn() {\n}"
+      }
+    ]
   }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition1.json
@@ -1,0 +1,174 @@
+{
+  "source": "new_connection7/main.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "65744",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION"
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "divide",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "int|error",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "a": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "a",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "b": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "b",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "new_connection7/functions.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "function divide(int a, int b) returns int|error{\n}"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition10.json
@@ -1,0 +1,255 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "56882",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 25,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 25,
+          "offset": 121
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "complexFunction",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "required": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "required",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "name": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "name",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "flag": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "boolean",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "flag",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "rest": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int...",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "rest",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 25,
+            "character": 7
+          },
+          "end": {
+            "line": 25,
+            "character": 121
+          }
+        },
+        "newText": "function complexFunction( int required, string name, boolean flag, int... rest) returns string"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition11.json
@@ -1,0 +1,114 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "86554",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 55,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 55,
+          "offset": 33
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "\\$dollar\\#hash",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 55,
+            "character": 7
+          },
+          "end": {
+            "line": 55,
+            "character": 33
+          }
+        },
+        "newText": "function \\$dollar\\#hash( ) "
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition12.json
@@ -1,0 +1,114 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "83569",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 52,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 52,
+          "offset": 24
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "'from",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 52,
+            "character": 7
+          },
+          "end": {
+            "line": 52,
+            "character": 24
+          }
+        },
+        "newText": "function 'from( ) "
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition13.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition13.json
@@ -1,0 +1,114 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "89517",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 58,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 58,
+          "offset": 20
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "ව",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {},
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 58,
+            "character": 7
+          },
+          "end": {
+            "line": 58,
+            "character": 20
+          }
+        },
+        "newText": "function ව( ) "
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition2.json
@@ -1,16 +1,25 @@
 {
+  "source": "empty.bal",
   "description": "Sample diagram node",
-  "codedata": {
-    "node": "FUNCTION_DEFINITION"
-  },
-  "output": {
-    "id": "31",
+  "diagram": {
+    "id": "73730",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 42,
+          "offset": 9
+        },
+        "endLine": {
+          "line": 42,
+          "offset": 43
+        }
+      }
     },
     "returning": false,
     "properties": {
@@ -20,7 +29,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
-        "value": "",
+        "value": "getCounter",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -31,7 +40,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "value": "",
+        "value": "int",
         "optional": true,
         "editable": true,
         "advanced": false
@@ -84,5 +93,22 @@
       }
     },
     "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 42,
+            "character": 9
+          },
+          "end": {
+            "line": 42,
+            "character": 43
+          }
+        },
+        "newText": "function getCounter( ) returns int"
+      }
+    ]
   }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition3.json
@@ -1,16 +1,25 @@
 {
+  "source": "empty.bal",
   "description": "Sample diagram node",
-  "codedata": {
-    "node": "FUNCTION_DEFINITION"
-  },
-  "output": {
-    "id": "31",
+  "diagram": {
+    "id": "33979",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "main.bal",
+        "startLine": {
+          "line": 2,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 2,
+          "offset": 34
+        }
+      }
     },
     "returning": false,
     "properties": {
@@ -20,7 +29,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
-        "value": "",
+        "value": "main",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -77,12 +86,65 @@
           "editable": false,
           "advanced": false
         },
-        "value": {},
+        "value": {
+          "name": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "name",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
         "optional": false,
         "editable": false,
         "advanced": false
       }
     },
     "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 2,
+            "character": 7
+          },
+          "end": {
+            "line": 2,
+            "character": 34
+          }
+        },
+        "newText": "function main( string name) "
+      }
+    ]
   }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition4.json
@@ -1,16 +1,25 @@
 {
+  "source": "empty.bal",
   "description": "Sample diagram node",
-  "codedata": {
-    "node": "FUNCTION_DEFINITION"
-  },
-  "output": {
-    "id": "31",
+  "diagram": {
+    "id": "32986",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 33
+        }
+      }
     },
     "returning": false,
     "properties": {
@@ -20,7 +29,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
-        "value": "",
+        "value": "simpleFunction",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -84,5 +93,22 @@
       }
     },
     "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 7
+          },
+          "end": {
+            "line": 1,
+            "character": 33
+          }
+        },
+        "newText": "function simpleFunction( ) "
+      }
+    ]
   }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition5.json
@@ -1,0 +1,185 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "31796",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "functions.bal",
+        "startLine": {
+          "line": 0,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 0,
+          "offset": 52
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "foo",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "foo": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "foo",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "bar": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int...",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "bar",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 52
+          }
+        },
+        "newText": "function foo( string foo, int... bar) returns string"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition6.json
@@ -1,0 +1,185 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "37959",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 6,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 6,
+          "offset": 46
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "add",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "int",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "a": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "a",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "b": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "b",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 6,
+            "character": 7
+          },
+          "end": {
+            "line": 6,
+            "character": 46
+          }
+        },
+        "newText": "function add( int a, int b) returns int"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition7.json
@@ -1,0 +1,185 @@
+{
+  "source": "empty.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "42945",
+    "metadata": {
+      "label": "Function Definition",
+      "description": "Define a function"
+    },
+    "codedata": {
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 11,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 11,
+          "offset": 72
+        }
+      }
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Function Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "greet",
+        "optional": false,
+        "editable": true,
+        "advanced": false
+      },
+      "type": {
+        "metadata": {
+          "label": "Return Type",
+          "description": "Type of the return value"
+        },
+        "valueType": "TYPE",
+        "value": "string",
+        "optional": true,
+        "editable": true,
+        "advanced": false
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Parameters",
+          "description": "Function parameters"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "TYPE",
+              "valueTypeConstraint": "anydata",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false
+        },
+        "value": {
+          "name": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "name",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "title": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "title",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
+        "optional": false,
+        "editable": false,
+        "advanced": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 7
+          },
+          "end": {
+            "line": 11,
+            "character": 72
+          }
+        },
+        "newText": "function greet( string name, string title) returns string"
+      }
+    ]
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition8.json
@@ -1,16 +1,25 @@
 {
+  "source": "empty.bal",
   "description": "Sample diagram node",
-  "codedata": {
-    "node": "FUNCTION_DEFINITION"
-  },
-  "output": {
-    "id": "31",
+  "diagram": {
+    "id": "78667",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 47,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 47,
+          "offset": 82
+        }
+      }
     },
     "returning": false,
     "properties": {
@@ -20,7 +29,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
-        "value": "",
+        "value": "processUser",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -31,7 +40,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "value": "",
+        "value": "string",
         "optional": true,
         "editable": true,
         "advanced": false
@@ -77,12 +86,65 @@
           "editable": false,
           "advanced": false
         },
-        "value": {},
+        "value": {
+          "user": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "record {|string name; int age;|}",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "user",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
         "optional": false,
         "editable": false,
         "advanced": false
       }
     },
     "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 47,
+            "character": 7
+          },
+          "end": {
+            "line": 47,
+            "character": 82
+          }
+        },
+        "newText": "function processUser( record {|string name; int age;|} user) returns string"
+      }
+    ]
   }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/function_definition9.json
@@ -1,16 +1,25 @@
 {
+  "source": "empty.bal",
   "description": "Sample diagram node",
-  "codedata": {
-    "node": "FUNCTION_DEFINITION"
-  },
-  "output": {
-    "id": "31",
+  "diagram": {
+    "id": "47881",
     "metadata": {
       "label": "Function Definition",
       "description": "Define a function"
     },
     "codedata": {
-      "node": "FUNCTION_DEFINITION"
+      "node": "FUNCTION_DEFINITION",
+      "lineRange": {
+        "fileName": "single.bal",
+        "startLine": {
+          "line": 16,
+          "offset": 7
+        },
+        "endLine": {
+          "line": 16,
+          "offset": 48
+        }
+      }
     },
     "returning": false,
     "properties": {
@@ -20,7 +29,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
-        "value": "",
+        "value": "sum",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -31,7 +40,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "value": "",
+        "value": "int",
         "optional": true,
         "editable": true,
         "advanced": false
@@ -77,12 +86,65 @@
           "editable": false,
           "advanced": false
         },
-        "value": {},
+        "value": {
+          "numbers": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "int...",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "numbers",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          }
+        },
         "optional": false,
         "editable": false,
         "advanced": false
       }
     },
     "flags": 0
+  },
+  "output": {
+    "empty.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 16,
+            "character": 7
+          },
+          "end": {
+            "line": 16,
+            "character": 48
+          }
+        },
+        "newText": "function sum( int... numbers) returns int"
+      }
+    ]
   }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/generate_fn_definition.py
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/generate_fn_definition.py
@@ -19,6 +19,7 @@ under the License.
 import os
 import json
 import glob
+import re
 
 
 def write_json_file(json_file, output_file_name):
@@ -38,6 +39,17 @@ def write_json_file(json_file, output_file_name):
         json.dump(output_data, out, indent=4)
 
 
+def sort_key(filepath):
+    filename = os.path.basename(filepath)
+    name, _ = os.path.splitext(filename)
+    match = re.match(r"([^\d]+)(\d+)?", name)
+    if match:
+        prefix = match.group(1)
+        number = int(match.group(2)) if match.group(2) else 0
+        return (prefix, number)
+    return (name, 0)
+
+
 current_dir = os.path.dirname(os.path.abspath(__file__))
 fn_def_dir = os.path.normpath(os.path.join(
     current_dir, "..", "..", "function_definition", "config"))
@@ -46,6 +58,8 @@ node_template_dir = os.path.normpath(os.path.join(
 
 # Generate the configs for the function definitions
 json_files = glob.glob(os.path.join(fn_def_dir, "*.json"))
+json_files.sort(key=sort_key)
+print("\n".join(json_files))
 for idx, json_file in enumerate(json_files, 1):
     write_json_file(json_file, f"function_definition{idx}.json")
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/generate_fn_definition.py
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/generate_fn_definition.py
@@ -1,0 +1,54 @@
+'''
+Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+
+WSO2 LLC. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+'''
+
+import os
+import json
+import glob
+
+
+def write_json_file(json_file, output_file_name):
+    with open(json_file, "r") as f:
+        # Read the entire JSON content into DIAGRAM
+        diagram = json.load(f)
+
+    output_data = {
+        "source": "empty.bal",
+        "description": "Sample diagram node",
+        "output": {},
+        "diagram": diagram['output']
+    }
+
+    output_file = os.path.join(current_dir, output_file_name)
+    with open(output_file, "w") as out:
+        json.dump(output_data, out, indent=4)
+
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+fn_def_dir = os.path.normpath(os.path.join(
+    current_dir, "..", "..", "function_definition", "config"))
+node_template_dir = os.path.normpath(os.path.join(
+    current_dir, "..", "..", "node_template", "config"))
+
+# Generate the configs for the function definitions
+json_files = glob.glob(os.path.join(fn_def_dir, "*.json"))
+for idx, json_file in enumerate(json_files, 1):
+    write_json_file(json_file, f"function_definition{idx}.json")
+
+# Generate the config for the node template
+template_file = os.path.join(node_template_dir, "function_definition.json")
+write_json_file(template_file, "function_definition.json")

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/generate_fn_definition.py
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/generate_fn_definition.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
 
 WSO2 LLC. licenses this file to you under the Apache License,
 Version 2.0 (the "License"); you may not use this file except

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/function_definition/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/function_definition/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "nipunaf"
+name = "new_connection1"
+version = "0.1.0"
+distribution = "2201.9.2"
+
+[build-options]
+observabilityIncluded = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/function_definition/functions.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/function_definition/functions.bal
@@ -1,0 +1,4 @@
+
+function greet(string name) returns string {
+    return "Hello, " + name + "!";
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/function_definition/main.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/source/function_definition/main.bal
@@ -1,0 +1,3 @@
+public function main() {
+
+}


### PR DESCRIPTION
## Purpose
The PR introduces the following changes to the existing APIs:

1. Support function definition in the `getNodeTemplate` API
2. Support writing a function definition in the `getSourceCode` API
    1. For new functions, ensure "functions.bal" exists, as the LS will provide the text edit at the end of this line.
    2. For existing functions, the text edit will only modify the function name and signature

The PR introduces a new API endpoint `flowDesignService/functionDefinition` that retrieves function definitions using the components API response.