### PR TITLE
Update the version dependencies after the U11 release

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/build.gradle
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/build.gradle
@@ -107,14 +107,26 @@ def pullBallerinaModule(String packageName) {
             def errOutput = new ByteArrayOutputStream()
             def result = exec {
                 ignoreExitValue = true
+
+                // Check if the package exists in the ballerina user 
+                def centralRepoDir = new File(System.getProperty("user.home"), ".ballerina/repositories/central.ballerina.io/bala/ballerinax")
+                if (centralRepoDir.exists()) {
+                    def pkgDir = new File(centralRepoDir, packageName)
+                    if (pkgDir.exists()) {
+                        commandLine 'echo', "Package ${packageName} exists"
+                        return
+                    }
+                }
+
+                def ballPullCommand = "bal pull ballerinax/${packageName}"
                 if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
-                    commandLine 'cmd', '/c', 'bal', 'pull', packageName
+                    commandLine 'cmd', '/c', ballPullCommand
                 } else {
-                    commandLine 'bal', 'pull', packageName
+                    commandLine '/bin/sh', '-c', ballPullCommand
                 }
                 errorOutput = errOutput
             }
-            if (result.exitValue != 0 && !errOutput.toString().contains("package already exists in the home repository")) {
+            if (result.exitValue != 0) {
                 println errOutput
                 throw new GradleException("Failed to pull Ballerina module: ${packageName}")
             }
@@ -122,11 +134,11 @@ def pullBallerinaModule(String packageName) {
     }
 }
 
-test.dependsOn pullBallerinaModule('ballerinax/redis')
-test.dependsOn pullBallerinaModule('ballerinax/trigger.salesforce')
-test.dependsOn pullBallerinaModule('ballerinax/github')
-test.dependsOn pullBallerinaModule('ballerinax/snowflake')
-test.dependsOn pullBallerinaModule('ballerinax/docusign.dsadmin')
+test.dependsOn pullBallerinaModule('redis')
+test.dependsOn pullBallerinaModule('trigger.salesforce')
+test.dependsOn pullBallerinaModule('github')
+test.dependsOn pullBallerinaModule('snowflake')
+test.dependsOn pullBallerinaModule('docusign.dsadmin')
 
 test {
     dependsOn {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -208,7 +208,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -216,7 +216,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -319,7 +319,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -327,7 +327,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {
@@ -586,7 +586,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -594,7 +594,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "clients.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
@@ -672,7 +672,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -680,7 +680,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.13.0",
+                          "version": "2.13.2",
                           "lineRange": {
                             "fileName": "main.bal",
                             "startLine": {
@@ -1625,7 +1625,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1633,7 +1633,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "main.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/data_mapper1.json
@@ -688,7 +688,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -696,7 +696,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "main.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
@@ -143,7 +143,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -151,7 +151,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -388,7 +388,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -396,7 +396,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "error_handler.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
@@ -143,7 +143,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -151,7 +151,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -424,7 +424,7 @@
                         "metadata": {
                           "label": "post",
                           "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -432,7 +432,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "post",
-                          "version": "2.13.0",
+                          "version": "2.13.2",
                           "lineRange": {
                             "fileName": "error_handler.bal",
                             "startLine": {
@@ -707,7 +707,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -715,7 +715,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "error_handler.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
@@ -83,7 +83,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -91,7 +91,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "error_handler.bal",
                     "startLine": {
@@ -375,7 +375,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -383,7 +383,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "error_handler.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -275,7 +275,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -283,7 +283,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -275,7 +275,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -283,7 +283,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
@@ -303,7 +303,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -311,7 +311,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {
@@ -702,7 +702,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -710,7 +710,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-user1.json
@@ -766,7 +766,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -774,7 +774,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "function_call.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
@@ -306,7 +306,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -314,7 +314,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
@@ -346,7 +346,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -354,7 +354,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
@@ -419,7 +419,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -427,7 +427,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -586,7 +586,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -594,7 +594,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
@@ -506,7 +506,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -514,7 +514,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
@@ -273,7 +273,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -281,7 +281,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
@@ -251,7 +251,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -259,7 +259,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
@@ -394,7 +394,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -402,7 +402,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
@@ -467,7 +467,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -475,7 +475,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
@@ -321,7 +321,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -329,7 +329,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
@@ -306,7 +306,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -314,7 +314,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "if_node_windows.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
@@ -83,7 +83,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -91,7 +91,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "nested_node.bal",
                     "startLine": {
@@ -229,7 +229,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -237,7 +237,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
@@ -140,7 +140,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -148,7 +148,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.13.0",
+                          "version": "2.13.2",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -288,7 +288,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -296,7 +296,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.13.0",
+                          "version": "2.13.2",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -475,7 +475,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -483,7 +483,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node3.json
@@ -102,7 +102,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -110,7 +110,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
@@ -169,7 +169,7 @@
                                 "metadata": {
                                   "label": "post",
                                   "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                                 },
                                 "codedata": {
                                   "node": "REMOTE_ACTION_CALL",
@@ -177,7 +177,7 @@
                                   "module": "http",
                                   "object": "Client",
                                   "symbol": "post",
-                                  "version": "2.13.0",
+                                  "version": "2.13.2",
                                   "lineRange": {
                                     "fileName": "nested_node.bal",
                                     "startLine": {
@@ -357,7 +357,7 @@
                         "metadata": {
                           "label": "get",
                           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -365,7 +365,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "get",
-                          "version": "2.13.0",
+                          "version": "2.13.2",
                           "lineRange": {
                             "fileName": "nested_node.bal",
                             "startLine": {
@@ -501,7 +501,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -509,7 +509,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "nested_node.bal",
                     "startLine": {
@@ -647,7 +647,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -655,7 +655,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
@@ -169,7 +169,7 @@
                                 "metadata": {
                                   "label": "post",
                                   "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                                 },
                                 "codedata": {
                                   "node": "REMOTE_ACTION_CALL",
@@ -177,7 +177,7 @@
                                   "module": "http",
                                   "object": "Client",
                                   "symbol": "post",
-                                  "version": "2.13.0",
+                                  "version": "2.13.2",
                                   "lineRange": {
                                     "fileName": "nested_node.bal",
                                     "startLine": {
@@ -400,7 +400,7 @@
                                 "metadata": {
                                   "label": "get",
                                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                                 },
                                 "codedata": {
                                   "node": "REMOTE_ACTION_CALL",
@@ -408,7 +408,7 @@
                                   "module": "http",
                                   "object": "Client",
                                   "symbol": "get",
-                                  "version": "2.13.0",
+                                  "version": "2.13.2",
                                   "lineRange": {
                                     "fileName": "nested_node.bal",
                                     "startLine": {
@@ -582,7 +582,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -590,7 +590,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "nested_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -565,7 +565,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -573,7 +573,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -676,7 +676,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -684,7 +684,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -565,7 +565,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -573,7 +573,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -676,7 +676,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -684,7 +684,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection3.json
@@ -42,7 +42,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -50,7 +50,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -153,7 +153,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -161,7 +161,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {
@@ -817,7 +817,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -825,7 +825,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "new_connection.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get1.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -155,7 +155,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -163,7 +163,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -272,7 +272,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -280,7 +280,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -167,7 +167,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -175,7 +175,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -271,7 +271,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -279,7 +279,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -376,7 +376,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -384,7 +384,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -470,7 +470,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -478,7 +478,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -422,7 +422,7 @@
         "metadata": {
           "label": "get",
           "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -430,7 +430,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -516,7 +516,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -524,7 +524,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post1.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "post",
           "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -188,7 +188,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -196,7 +196,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -353,7 +353,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -361,7 +361,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "post",
           "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -200,7 +200,7 @@
         "metadata": {
           "label": "post",
           "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -208,7 +208,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -337,7 +337,7 @@
         "metadata": {
           "label": "post",
           "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -345,7 +345,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -464,7 +464,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -472,7 +472,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -422,7 +422,7 @@
         "metadata": {
           "label": "post",
           "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "REMOTE_ACTION_CALL",
@@ -430,7 +430,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -549,7 +549,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -557,7 +557,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -181,7 +181,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -189,7 +189,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -329,7 +329,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -337,7 +337,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -470,7 +470,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -478,7 +478,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -612,7 +612,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -620,7 +620,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -753,7 +753,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -761,7 +761,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -895,7 +895,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -903,7 +903,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1036,7 +1036,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1044,7 +1044,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1177,7 +1177,7 @@
         "metadata": {
           "label": "get",
           "description": "The client resource function to send HTTP GET requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1185,7 +1185,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "get",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {
@@ -1303,7 +1303,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1311,7 +1311,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_get_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
@@ -40,7 +40,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -48,7 +48,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -214,7 +214,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -222,7 +222,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -389,7 +389,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -397,7 +397,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -563,7 +563,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -571,7 +571,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -738,7 +738,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -746,7 +746,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -913,7 +913,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -921,7 +921,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -1087,7 +1087,7 @@
         "metadata": {
           "label": "post",
           "description": "The client resource function to send HTTP POST requests to HTTP endpoints.\n",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "RESOURCE_ACTION_CALL",
@@ -1095,7 +1095,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "post",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {
@@ -1263,7 +1263,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1271,7 +1271,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "http_post_node.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
@@ -97,7 +97,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -105,7 +105,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "simple_flow.bal",
                     "startLine": {
@@ -282,7 +282,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -290,7 +290,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "simple_flow.bal",
                     "startLine": {
@@ -452,7 +452,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -460,7 +460,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "simple_flow.bal",
             "startLine": {
@@ -834,7 +834,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -842,7 +842,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "simple_flow.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -203,7 +203,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -211,7 +211,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -571,7 +571,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -579,7 +579,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while2.json
@@ -103,7 +103,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -111,7 +111,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -203,7 +203,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -211,7 +211,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -499,7 +499,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -507,7 +507,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -203,7 +203,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -211,7 +211,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -546,7 +546,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -554,7 +554,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
@@ -203,7 +203,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -211,7 +211,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -527,7 +527,7 @@
                 "metadata": {
                   "label": "New Connection",
                   "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "NEW_CONNECTION",
@@ -535,7 +535,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "init",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -1051,7 +1051,7 @@
                         "metadata": {
                           "label": "post",
                           "description": "The `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n",
-                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                         },
                         "codedata": {
                           "node": "REMOTE_ACTION_CALL",
@@ -1059,7 +1059,7 @@
                           "module": "http",
                           "object": "Client",
                           "symbol": "post",
-                          "version": "2.13.0",
+                          "version": "2.13.2",
                           "lineRange": {
                             "fileName": "while.bal",
                             "startLine": {
@@ -1425,7 +1425,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -1433,7 +1433,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -203,7 +203,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -211,7 +211,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -584,7 +584,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -592,7 +592,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -203,7 +203,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -211,7 +211,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -584,7 +584,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -592,7 +592,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -203,7 +203,7 @@
                 "metadata": {
                   "label": "get",
                   "description": "The `Client.get()` function can be used to send HTTP GET requests to HTTP endpoints.\n",
-                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+                  "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
                 },
                 "codedata": {
                   "node": "REMOTE_ACTION_CALL",
@@ -211,7 +211,7 @@
                   "module": "http",
                   "object": "Client",
                   "symbol": "get",
-                  "version": "2.13.0",
+                  "version": "2.13.2",
                   "lineRange": {
                     "fileName": "while.bal",
                     "startLine": {
@@ -670,7 +670,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -678,7 +678,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "while.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/proj.json
@@ -216,7 +216,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -224,7 +224,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "main.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/module_nodes/config/single.json
@@ -216,7 +216,7 @@
         "metadata": {
           "label": "New Connection",
           "description": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes the functions for the standard HTTP methods forwarding a received request and sending requests\nusing custom HTTP verbs.",
-          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.0.png"
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.13.2.png"
         },
         "codedata": {
           "node": "NEW_CONNECTION",
@@ -224,7 +224,7 @@
           "module": "http",
           "object": "Client",
           "symbol": "init",
-          "version": "2.13.0",
+          "version": "2.13.2",
           "lineRange": {
             "fileName": "source.bal",
             "startLine": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
@@ -23,7 +23,7 @@
                     "name": "ClientObject",
                     "orgName": "ballerina",
                     "moduleName": "http",
-                    "version": "2.13.0"
+                    "version": "2.13.2"
                   },
                   "defaultable": false,
                   "isRestType": false
@@ -41,7 +41,7 @@
               "name": "Client",
               "orgName": "ballerina",
               "moduleName": "http",
-              "version": "2.13.0"
+              "version": "2.13.2"
             },
             "defaultable": false,
             "isRestType": false

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
@@ -23,7 +23,7 @@
                     "name": "ClientObject",
                     "orgName": "ballerina",
                     "moduleName": "http",
-                    "version": "2.13.0"
+                    "version": "2.13.2"
                   },
                   "defaultable": false,
                   "isRestType": false
@@ -41,7 +41,7 @@
               "name": "Client",
               "orgName": "ballerina",
               "moduleName": "http",
-              "version": "2.13.0"
+              "version": "2.13.2"
             },
             "defaultable": false,
             "isRestType": false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=2.0.0-SNAPSHOT
-ballerinaLangVersion=2201.11.0-20250127-101700-a4b67fe5
+ballerinaLangVersion=2201.11.0-20250214-135000-5f26a7b3
 
-ballerinaGradlePluginVersion=2.2.6
+ballerinaGradlePluginVersion=2.3.0
 checkStyleToolVersion=10.12.1
 downloadPluginVersion=5.4.0
 eclipseLsp4jVersion=0.12.0
@@ -20,38 +20,38 @@ swaggerParserVersion=2.1.22
 openAPICoreVersion=2.2.0-20241205-142900-95f0235
 
 # Ballerinax Observer
-observeVersion=1.4.0-20250127-170200-f9c0dec
-observeInternalVersion=1.4.0-20250127-171000-b05ff1d
+observeVersion=1.4.0
+observeInternalVersion=1.4.0
 
 # Standard Library Dependencies
 # Stdlib Level 01
-stdlibIoVersion=1.7.0-20250127-170200-0d36f73
-stdlibTimeVersion=2.6.0-20250127-170200-86bdc5a
-stdlibUrlVersion=2.5.0-20250127-170200-e4cac31
+stdlibIoVersion=1.7.0
+stdlibTimeVersion=2.6.0
+stdlibUrlVersion=2.5.0
 
 # Stdlib Level 02
-stdlibConstraintVersion=1.6.0-20250127-170900-48ad9ae
-stdlibCryptoVersion=2.8.0-20250127-170800-6c52ac3
-stdlibLogVersion=2.11.0-20250127-173700-45079a8
-stdlibOsVersion=1.9.0-20250127-170900-54f2a57
-stdlibRandomVersion=1.6.0-20250127-172500-3217a75
+stdlibConstraintVersion=1.6.0
+stdlibCryptoVersion=2.8.0
+stdlibLogVersion=2.11.0
+stdlibOsVersion=1.9.0
+stdlibRandomVersion=1.6.0
 
 # Stdlib Level 03
-stdlibUuidVersion=1.9.0-20250127-181300-0f9a3f6
+stdlibUuidVersion=1.9.0
 
 # Stdlib Level 04
-stdlibAuthVersion=2.13.0-20250127-182300-e14b66f
-stdlibOAuth2Version=2.13.0-20250127-182700-5ce88a0
-stdlibJsonDataVersion=1.0.0-20241125-114000-0c2f457
+stdlibAuthVersion=2.13.0
+stdlibOAuth2Version=2.13.0
+stdlibJsonDataVersion=1.0.0
 
 # Stdlib Level 05
-stdlibHttpVersion=2.13.0-20250205-101600-0d1c9f5
+stdlibHttpVersion=2.13.2
 
 # Stdlib Level 06
-stdlibGrpcVersion=1.13.0-20250129-104300-b14edc5
+stdlibGrpcVersion=1.13.0
 
 # Stdlib Level 07
-stdlibGraphqlVersion=1.15.0-20250129-150700-999a585
+stdlibGraphqlVersion=1.15.0
 
 # Persist Tool
-persistToolVersion=1.5.0-20250129-192900-d35a8d7
+persistToolVersion=1.5.0


### PR DESCRIPTION
## Purpose
The PR aligns the test cases with the versions produced in U11, while also improving the bal pull method to consider the ballerina user home.