### PR TITLE
Fix the issue where irrelevant diagnosis are shown in nodes

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DiagnosticHandler.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/DiagnosticHandler.java
@@ -64,6 +64,11 @@ public class DiagnosticHandler {
         LinePosition nodeStartLine = nodeLineRange.startLine();
 
         while (currentDiagnostic != null) {
+            // Check if the diagnostic is in the same file as the node
+            if (!nodeLineRange.fileName().equals(currentDiagnostic.location().lineRange().fileName())) {
+                next();
+                continue;
+            }
 
             // Checks if the diagnostic has passed the node
             LineRange diagnosticLineRange = currentDiagnostic.location().lineRange();

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics5.json
@@ -1,0 +1,101 @@
+{
+  "start": {
+    "line": 0,
+    "offset": 0
+  },
+  "end": {
+    "line": 2,
+    "offset": 1
+  },
+  "source": "diagnostics/functions.bal",
+  "description": "Tests a simple diagram flow",
+  "diagram": {
+    "fileName": "functions.bal",
+    "nodes": [
+      {
+        "id": "32303",
+        "metadata": {
+          "label": "Start"
+        },
+        "codedata": {
+          "node": "EVENT_START",
+          "lineRange": {
+            "fileName": "functions.bal",
+            "startLine": {
+              "line": 0,
+              "offset": 16
+            },
+            "endLine": {
+              "line": 2,
+              "offset": 1
+            }
+          },
+          "sourceCode": "function name() {\n    string a = \"1\";\n}"
+        },
+        "returning": false,
+        "flags": 0
+      },
+      {
+        "id": "32879",
+        "metadata": {
+          "label": "Variable",
+          "description": "Assign a value to a variable"
+        },
+        "codedata": {
+          "node": "VARIABLE",
+          "lineRange": {
+            "fileName": "functions.bal",
+            "startLine": {
+              "line": 1,
+              "offset": 4
+            },
+            "endLine": {
+              "line": 1,
+              "offset": 19
+            }
+          },
+          "sourceCode": "string a = \"1\";"
+        },
+        "returning": false,
+        "properties": {
+          "expression": {
+            "metadata": {
+              "label": "Expression",
+              "description": "Initialize with value"
+            },
+            "valueType": "EXPRESSION",
+            "value": "\"1\"",
+            "optional": true,
+            "editable": true,
+            "advanced": false
+          },
+          "variable": {
+            "metadata": {
+              "label": "Name",
+              "description": "Name of the variable"
+            },
+            "valueType": "IDENTIFIER",
+            "value": "a",
+            "optional": false,
+            "editable": true,
+            "advanced": false
+          },
+          "type": {
+            "metadata": {
+              "label": "Type",
+              "description": "Type of the variable"
+            },
+            "valueType": "TYPE",
+            "value": "string",
+            "placeholder": "var",
+            "optional": false,
+            "editable": true,
+            "advanced": false
+          }
+        },
+        "flags": 0
+      }
+    ],
+    "connections": []
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/diagnostics/automation.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/diagnostics/automation.bal
@@ -1,0 +1,3 @@
+function foo() {
+    string s = 121;
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/diagnostics/functions.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/diagnostics/functions.bal
@@ -1,0 +1,3 @@
+function name() {
+    string a = "1";
+}


### PR DESCRIPTION
## Purpose

The PR modifies the diagnostic handler to skip the current diagnostic if it exists in a different file