### PR TITLE
Add support for path parameters in variable types

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
@@ -315,6 +315,10 @@
     {
       "name": "Parameters",
       "types": []
+    },
+    {
+      "name": "Path Parameters",
+      "types": []
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
@@ -311,6 +311,29 @@
           }
         }
       ]
+    },
+    {
+      "name": "Path Parameters",
+      "types": [
+        {
+          "name": "user",
+          "type": {
+            "typeName": "string",
+            "optional": false,
+            "defaultable": false,
+            "isRestType": false
+          }
+        },
+        {
+          "name": "val",
+          "type": {
+            "typeName": "int",
+            "optional": false,
+            "defaultable": false,
+            "isRestType": true
+          }
+        }
+      ]
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/source/data_mapper/service.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/source/data_mapper/service.bal
@@ -9,7 +9,7 @@ configurable table<Input> key(name) configTable = table [
 ];
 
 service /p1 on new http:Listener(9091) {
-    resource function get greeting(string value, int i = 12) returns json|http:InternalServerError {
+    resource function get greeting/[string user]/[int... val](string value, int i = 12) returns json|http:InternalServerError {
         do {
             Input localInput = {name: "John", age: 30};
 


### PR DESCRIPTION
## Purpose
The changes add support for Path Parameters in the expression editor helper pane, allowing it to handle both regular path parameters (like [string user]) and rest-type path parameters (like [int... val]) alongside existing variable categories.