### PR TITLE
Change the return type of the `expressionEditor/types` API

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -1092,7 +1092,7 @@ class CodeAnalyzer extends NodeVisitor {
     public void visit(FailStatementNode failStatementNode) {
         startNode(NodeKind.FAIL, failStatementNode)
                 .properties().expression(failStatementNode.expression(), FailBuilder.FAIL_EXPRESSION_DOC, false,
-                        TypesGenerator.ERROR_TYPE_NAME);
+                        TypesGenerator.TYPE_ERROR);
         endNode(failStatementNode);
     }
 
@@ -1271,7 +1271,7 @@ class CodeAnalyzer extends NodeVisitor {
     public void visit(PanicStatementNode panicStatementNode) {
         startNode(NodeKind.PANIC, panicStatementNode)
                 .properties().expression(panicStatementNode.expression(), PanicBuilder.PANIC_EXPRESSION_DOC, false,
-                        TypesGenerator.ERROR_TYPE_NAME);
+                        TypesGenerator.TYPE_ERROR);
         endNode(panicStatementNode);
     }
 

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/SuggestedModelGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/SuggestedModelGenerator.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+
 package io.ballerina.flowmodelgenerator.core;
 
 import com.google.gson.Gson;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypeCompletionItemBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypeCompletionItemBuilder.java
@@ -1,0 +1,165 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core;
+
+import io.ballerina.compiler.api.symbols.Documentable;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.common.utils.SymbolUtil;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.CompletionItemLabelDetails;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * This class is being used to build Type completion item.
+ * TODO: This is a copy of the implementation used in the the language-server core. We need to refactor the
+ *  visibility of that class to reuse the implementation.
+ *
+ * @since 2.0.0
+ */
+public final class TypeCompletionItemBuilder {
+
+    private TypeCompletionItemBuilder() {
+    }
+
+    /**
+     * Creates and returns a completion item.
+     *
+     * @param bSymbol Symbol or null
+     * @param label   label
+     * @param detail  detail
+     * @return {@link CompletionItem}
+     */
+    public static CompletionItem build(Symbol bSymbol, String label, String detail) {
+        CompletionItemLabelDetails completionItemLabelDetails = new CompletionItemLabelDetails();
+        completionItemLabelDetails.setDetail(detail);
+        CompletionItem item = new CompletionItem();
+        item.setLabel(label);
+        String insertText = CommonUtil.escapeSpecialCharsInInsertText(label);
+        item.setInsertText(insertText);
+        setMeta(item, bSymbol, completionItemLabelDetails);
+        item.setLabelDetails(completionItemLabelDetails);
+        return item;
+    }
+
+    private static void setMeta(CompletionItem item, Symbol bSymbol,
+                                CompletionItemLabelDetails completionItemLabelDetails) {
+        if (bSymbol == null) {
+            item.setKind(CompletionItemKind.Unit);
+            completionItemLabelDetails.setDescription("type");
+            return;
+        }
+        if (bSymbol.kind() == SymbolKind.MODULE) {
+            // package
+            item.setKind(CompletionItemKind.Module);
+            return;
+        }
+        if (bSymbol.kind() == SymbolKind.ENUM) {
+            item.setKind(CompletionItemKind.Enum);
+            completionItemLabelDetails.setDescription("enum");
+            return;
+        }
+        Optional<? extends TypeSymbol> typeDescriptor = SymbolUtil.getTypeDescriptor(bSymbol);
+        typeDescriptor = (typeDescriptor.isPresent() && typeDescriptor.get().typeKind() == TypeDescKind.TYPE_REFERENCE)
+                ? Optional.of(((TypeReferenceTypeSymbol) typeDescriptor.get()).typeDescriptor()) : typeDescriptor;
+
+        if (typeDescriptor.isEmpty() || typeDescriptor.get().typeKind() == null || typeDescriptor.get().typeKind() ==
+                TypeDescKind.COMPILATION_ERROR) {
+            item.setKind(CompletionItemKind.Unit);
+            completionItemLabelDetails.setDescription("type");
+            return;
+        }
+
+        //Or, else
+         /*else if (typeDescKind.isPresent() && typeDescKind.get() == TypeDescKind.FINITE) {
+            // Finite types
+            item.setKind(CompletionItemKind.TypeParameter);
+        }*/
+        switch (typeDescriptor.get().typeKind()) {
+            case UNION:
+                // Union types
+                List<TypeSymbol> memberTypes = new ArrayList<>(((UnionTypeSymbol) typeDescriptor.get())
+                        .memberTypeDescriptors());
+
+                // To handle cases where the source is incomplete and hence results in an empty union
+                if (memberTypes.isEmpty()) {
+                    item.setKind(CompletionItemKind.Unit);
+                    completionItemLabelDetails.setDescription("type");
+                    return;
+                }
+
+                boolean allMatch = memberTypes.stream()
+                        .allMatch(typeDesc -> typeDesc.typeKind() == memberTypes.get(0).typeKind());
+                if (allMatch) {
+                    switch (memberTypes.get(0).typeKind()) {
+                        case ERROR:
+                            item.setKind(CompletionItemKind.Event);
+                            break;
+                        case RECORD:
+                            item.setKind(CompletionItemKind.Struct);
+                            break;
+                        case OBJECT:
+                            item.setKind(CompletionItemKind.Interface);
+                            break;
+                        default:
+                            item.setKind(CompletionItemKind.TypeParameter);
+                            break;
+                    }
+                } else {
+                    item.setKind(CompletionItemKind.Enum);
+                }
+                break;
+            case RECORD:
+                item.setKind(CompletionItemKind.Struct);
+                break;
+            case OBJECT:
+                item.setKind(CompletionItemKind.Interface);
+                break;
+            case ERROR:
+                item.setKind(CompletionItemKind.Event);
+                break;
+            default:
+                item.setKind(CompletionItemKind.TypeParameter);
+        }
+
+        Documentable documentableSymbol = bSymbol instanceof Documentable ? (Documentable) bSymbol : null;
+        if (documentableSymbol != null && documentableSymbol.documentation().isPresent()
+                && documentableSymbol.documentation().get().description().isPresent()) {
+            item.setDocumentation(documentableSymbol.documentation().get().description().get());
+        }
+
+        // set sub bType
+        String name = typeDescriptor.get().kind() == SymbolKind.CLASS
+                ? typeDescriptor.get().kind().name()
+                : typeDescriptor.get().typeKind().getName();
+        String detail = name.substring(0, 1).toUpperCase(Locale.ENGLISH)
+                + name.substring(1).toLowerCase(Locale.ENGLISH);
+        completionItemLabelDetails.setDescription(detail);
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.flowmodelgenerator.core;
 
-import com.google.gson.Gson;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.Types;
 import io.ballerina.compiler.api.symbols.SymbolKind;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -42,12 +42,13 @@ import java.util.stream.Collectors;
  */
 public class TypesGenerator {
 
-    private final Gson gson;
     private final Map<String, TypeSymbol> builtinTypeSymbols;
     private final Map<String, CompletionItem> builtinTypeCompletionItems;
 
     private static final String PRIMITIVE_TYPE = "Primitive";
     private static final String USER_DEFINED_TYPE = "User-Defined";
+    private static final List<SymbolKind> TYPE_SYMBOL_KINDS =
+            List.of(SymbolKind.TYPE_DEFINITION, SymbolKind.CLASS, SymbolKind.ENUM);
 
     // Builtin type names
     public static final String TYPE_STRING = TypeKind.STRING.typeName();
@@ -70,14 +71,13 @@ public class TypesGenerator {
     public static final String TYPE_READONLY = TypeKind.READONLY.typeName();
 
     private TypesGenerator() {
-        this.gson = new Gson();
         this.builtinTypeSymbols = new LinkedHashMap<>();
         this.builtinTypeCompletionItems = new LinkedHashMap<>();
     }
 
     public Either<List<CompletionItem>, CompletionList> getTypes(SemanticModel semanticModel) {
         List<CompletionItem> completionItems = semanticModel.moduleSymbols().parallelStream()
-                .filter(symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION)
+                .filter(symbol -> TYPE_SYMBOL_KINDS.contains(symbol.kind()))
                 .map(symbol -> TypeCompletionItemBuilder.build(symbol, symbol.getName().orElse(""), USER_DEFINED_TYPE))
                 .collect(Collectors.toCollection(ArrayList::new));
         initializeBuiltinTypes(semanticModel);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FailBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FailBuilder.java
@@ -61,6 +61,6 @@ public class FailBuilder extends NodeBuilder {
 
     @Override
     public void setConcreteTemplateData(TemplateContext context) {
-        properties().expression("", FAIL_EXPRESSION_DOC, false, TypesGenerator.ERROR_TYPE_NAME);
+        properties().expression("", FAIL_EXPRESSION_DOC, false, TypesGenerator.TYPE_ERROR);
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/PanicBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/PanicBuilder.java
@@ -61,6 +61,6 @@ public class PanicBuilder extends NodeBuilder {
 
     @Override
     public void setConcreteTemplateData(TemplateContext context) {
-        properties().expression("", PANIC_EXPRESSION_DOC, false, TypesGenerator.ERROR_TYPE_NAME);
+        properties().expression("", PANIC_EXPRESSION_DOC, false, TypesGenerator.TYPE_ERROR);
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorService.java
@@ -103,19 +103,17 @@ public class ExpressionEditorService implements ExtendedLanguageServerService {
     }
 
     @JsonRequest
-    public CompletableFuture<ExpressionEditorTypeResponse> types(VisibleVariableTypeRequest request) {
+    public CompletableFuture<Either<List<CompletionItem>, CompletionList>> types(VisibleVariableTypeRequest request) {
         return CompletableFuture.supplyAsync(() -> {
-            ExpressionEditorTypeResponse response = new ExpressionEditorTypeResponse();
             try {
                 Path filePath = Path.of(request.filePath());
                 Project project = this.workspaceManagerProxy.get().loadProject(filePath);
                 SemanticModel semanticModel = this.workspaceManagerProxy.get().semanticModel(filePath).orElseGet(
                         () -> project.currentPackage().getDefaultModule().getCompilation().getSemanticModel());
-                response.setTypes(TypesGenerator.getInstance().getTypes(semanticModel));
+                return TypesGenerator.getInstance().getTypes(semanticModel);
             } catch (Throwable e) {
-                response.setError(e);
+                return Either.forRight(new CompletionList());
             }
-            return response;
         });
     }
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorService.java
@@ -34,7 +34,6 @@ import io.ballerina.flowmodelgenerator.extension.request.ExpressionEditorSignatu
 import io.ballerina.flowmodelgenerator.extension.request.FunctionCallTemplateRequest;
 import io.ballerina.flowmodelgenerator.extension.request.ImportModuleRequest;
 import io.ballerina.flowmodelgenerator.extension.request.VisibleVariableTypeRequest;
-import io.ballerina.flowmodelgenerator.extension.response.ExpressionEditorTypeResponse;
 import io.ballerina.flowmodelgenerator.extension.response.FunctionCallTemplateResponse;
 import io.ballerina.flowmodelgenerator.extension.response.SuccessResponse;
 import io.ballerina.flowmodelgenerator.extension.response.VisibleVariableTypesResponse;

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorCompletionTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorCompletionTest.java
@@ -41,7 +41,7 @@ import java.util.List;
  */
 public class ExpressionEditorCompletionTest extends AbstractLSTest {
 
-    private static final Type COMPLETION_RESPONSE_TYPE = new TypeToken<List<CompletionItem>>() { }.getType();
+    public static final Type COMPLETION_RESPONSE_TYPE = new TypeToken<List<CompletionItem>>() { }.getType();
 
     @Override
     @Test(dataProvider = "data-provider")

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorTypesTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorTypesTest.java
@@ -18,17 +18,18 @@
 
 package io.ballerina.flowmodelgenerator.extension;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.ballerina.flowmodelgenerator.extension.request.VisibleVariableTypeRequest;
 import io.ballerina.modelgenerator.commons.AbstractLSTest;
 import io.ballerina.tools.text.LinePosition;
+import org.eclipse.lsp4j.CompletionItem;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Tests for the expression editor types service.
@@ -46,11 +47,11 @@ public class ExpressionEditorTypesTest extends AbstractLSTest {
                 new VisibleVariableTypeRequest(getSourcePath(testConfig.source()), testConfig.position());
         JsonObject response = getResponse(request);
 
-        JsonArray actualExpressionTypes = response.get("types").getAsJsonArray();
-        if (!actualExpressionTypes.equals(testConfig.types())) {
+        List<CompletionItem> actualCompletions = gson.fromJson(response.get("left").getAsJsonArray(),
+                ExpressionEditorCompletionTest.COMPLETION_RESPONSE_TYPE);
+        if (!assertArray("completions", actualCompletions, testConfig.completions())) {
             TestConfig updatedConfig = new TestConfig(testConfig.description(), testConfig.source(),
-                    testConfig.position(), actualExpressionTypes);
-            compareJsonElements(actualExpressionTypes, testConfig.types());
+                    testConfig.position(), actualCompletions);
 //            updateConfig(configJsonPath, updatedConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }
@@ -76,6 +77,7 @@ public class ExpressionEditorTypesTest extends AbstractLSTest {
         return "expressionEditor";
     }
 
-    private record TestConfig(String description, String source, LinePosition position, JsonArray types) {
+    private record TestConfig(String description, String source, LinePosition position,
+                              List<CompletionItem> completions) {
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
@@ -5,31 +5,234 @@
     "line": 16,
     "offset": 0
   },
-  "types": [
-    "Input",
-    "Output",
-    "Location",
-    "Address",
-    "Employee",
-    "Person",
-    "Admission",
-    "string",
-    "boolean",
-    "int",
-    "float",
-    "decimal",
-    "xml",
-    "byte",
-    "error",
-    "json",
-    "any",
-    "anydata",
-    "function",
-    "future",
-    "typedesc",
-    "handle",
-    "stream",
-    "never",
-    "readonly"
+  "completions": [
+    {
+      "label": "Input",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Input"
+    },
+    {
+      "label": "Output",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Output"
+    },
+    {
+      "label": "Location",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Represents a geographical location.\n"
+      },
+      "insertText": "Location"
+    },
+    {
+      "label": "Address",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Address"
+    },
+    {
+      "label": "Employee",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Employee"
+    },
+    {
+      "label": "Person",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Person"
+    },
+    {
+      "label": "Admission",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Admission"
+    },
+    {
+      "label": "string",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "String"
+      },
+      "kind": "TypeParameter",
+      "insertText": "string"
+    },
+    {
+      "label": "boolean",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Boolean"
+      },
+      "kind": "TypeParameter",
+      "insertText": "boolean"
+    },
+    {
+      "label": "int",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Int"
+      },
+      "kind": "TypeParameter",
+      "insertText": "int"
+    },
+    {
+      "label": "float",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Float"
+      },
+      "kind": "TypeParameter",
+      "insertText": "float"
+    },
+    {
+      "label": "decimal",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Decimal"
+      },
+      "kind": "TypeParameter",
+      "insertText": "decimal"
+    },
+    {
+      "label": "xml",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Xml"
+      },
+      "kind": "TypeParameter",
+      "insertText": "xml"
+    },
+    {
+      "label": "byte",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Byte"
+      },
+      "kind": "TypeParameter",
+      "insertText": "byte"
+    },
+    {
+      "label": "error",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Error"
+      },
+      "kind": "Event",
+      "insertText": "error"
+    },
+    {
+      "label": "json",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Json"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json"
+    },
+    {
+      "label": "any",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Any"
+      },
+      "kind": "TypeParameter",
+      "insertText": "any"
+    },
+    {
+      "label": "anydata",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Anydata"
+      },
+      "kind": "TypeParameter",
+      "insertText": "anydata"
+    },
+    {
+      "label": "function",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Function"
+      },
+      "kind": "TypeParameter",
+      "insertText": "function"
+    },
+    {
+      "label": "future",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Future"
+      },
+      "kind": "TypeParameter",
+      "insertText": "future"
+    },
+    {
+      "label": "typedesc",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Typedesc"
+      },
+      "kind": "TypeParameter",
+      "insertText": "typedesc"
+    },
+    {
+      "label": "handle",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Handle"
+      },
+      "kind": "TypeParameter",
+      "insertText": "handle"
+    },
+    {
+      "label": "stream",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Stream"
+      },
+      "kind": "TypeParameter",
+      "insertText": "stream"
+    },
+    {
+      "label": "never",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Never"
+      },
+      "kind": "TypeParameter",
+      "insertText": "never"
+    },
+    {
+      "label": "readonly",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Readonly"
+      },
+      "kind": "TypeParameter",
+      "insertText": "readonly"
+    }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
@@ -5,31 +5,234 @@
     "line": 14,
     "offset": 0
   },
-  "types": [
-    "Input",
-    "Output",
-    "Location",
-    "Address",
-    "Employee",
-    "Person",
-    "Admission",
-    "string",
-    "boolean",
-    "int",
-    "float",
-    "decimal",
-    "xml",
-    "byte",
-    "error",
-    "json",
-    "any",
-    "anydata",
-    "function",
-    "future",
-    "typedesc",
-    "handle",
-    "stream",
-    "never",
-    "readonly"
+  "completions": [
+    {
+      "label": "Input",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Input"
+    },
+    {
+      "label": "Output",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Output"
+    },
+    {
+      "label": "Location",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Represents a geographical location.\n"
+      },
+      "insertText": "Location"
+    },
+    {
+      "label": "Address",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Address"
+    },
+    {
+      "label": "Employee",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Employee"
+    },
+    {
+      "label": "Person",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Person"
+    },
+    {
+      "label": "Admission",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Admission"
+    },
+    {
+      "label": "string",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "String"
+      },
+      "kind": "TypeParameter",
+      "insertText": "string"
+    },
+    {
+      "label": "boolean",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Boolean"
+      },
+      "kind": "TypeParameter",
+      "insertText": "boolean"
+    },
+    {
+      "label": "int",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Int"
+      },
+      "kind": "TypeParameter",
+      "insertText": "int"
+    },
+    {
+      "label": "float",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Float"
+      },
+      "kind": "TypeParameter",
+      "insertText": "float"
+    },
+    {
+      "label": "decimal",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Decimal"
+      },
+      "kind": "TypeParameter",
+      "insertText": "decimal"
+    },
+    {
+      "label": "xml",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Xml"
+      },
+      "kind": "TypeParameter",
+      "insertText": "xml"
+    },
+    {
+      "label": "byte",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Byte"
+      },
+      "kind": "TypeParameter",
+      "insertText": "byte"
+    },
+    {
+      "label": "error",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Error"
+      },
+      "kind": "Event",
+      "insertText": "error"
+    },
+    {
+      "label": "json",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Json"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json"
+    },
+    {
+      "label": "any",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Any"
+      },
+      "kind": "TypeParameter",
+      "insertText": "any"
+    },
+    {
+      "label": "anydata",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Anydata"
+      },
+      "kind": "TypeParameter",
+      "insertText": "anydata"
+    },
+    {
+      "label": "function",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Function"
+      },
+      "kind": "TypeParameter",
+      "insertText": "function"
+    },
+    {
+      "label": "future",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Future"
+      },
+      "kind": "TypeParameter",
+      "insertText": "future"
+    },
+    {
+      "label": "typedesc",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Typedesc"
+      },
+      "kind": "TypeParameter",
+      "insertText": "typedesc"
+    },
+    {
+      "label": "handle",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Handle"
+      },
+      "kind": "TypeParameter",
+      "insertText": "handle"
+    },
+    {
+      "label": "stream",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Stream"
+      },
+      "kind": "TypeParameter",
+      "insertText": "stream"
+    },
+    {
+      "label": "never",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Never"
+      },
+      "kind": "TypeParameter",
+      "insertText": "never"
+    },
+    {
+      "label": "readonly",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Readonly"
+      },
+      "kind": "TypeParameter",
+      "insertText": "readonly"
+    }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config3.json
@@ -1,31 +1,234 @@
 {
   "description": "",
   "source": "data_mapper",
-  "types": [
-    "Input",
-    "Output",
-    "Location",
-    "Address",
-    "Employee",
-    "Person",
-    "Admission",
-    "string",
-    "boolean",
-    "int",
-    "float",
-    "decimal",
-    "xml",
-    "byte",
-    "error",
-    "json",
-    "any",
-    "anydata",
-    "function",
-    "future",
-    "typedesc",
-    "handle",
-    "stream",
-    "never",
-    "readonly"
+  "completions": [
+    {
+      "label": "Input",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Input"
+    },
+    {
+      "label": "Output",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Output"
+    },
+    {
+      "label": "Location",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Represents a geographical location.\n"
+      },
+      "insertText": "Location"
+    },
+    {
+      "label": "Address",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Address"
+    },
+    {
+      "label": "Employee",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Employee"
+    },
+    {
+      "label": "Person",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Person"
+    },
+    {
+      "label": "Admission",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Admission"
+    },
+    {
+      "label": "string",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "String"
+      },
+      "kind": "TypeParameter",
+      "insertText": "string"
+    },
+    {
+      "label": "boolean",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Boolean"
+      },
+      "kind": "TypeParameter",
+      "insertText": "boolean"
+    },
+    {
+      "label": "int",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Int"
+      },
+      "kind": "TypeParameter",
+      "insertText": "int"
+    },
+    {
+      "label": "float",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Float"
+      },
+      "kind": "TypeParameter",
+      "insertText": "float"
+    },
+    {
+      "label": "decimal",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Decimal"
+      },
+      "kind": "TypeParameter",
+      "insertText": "decimal"
+    },
+    {
+      "label": "xml",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Xml"
+      },
+      "kind": "TypeParameter",
+      "insertText": "xml"
+    },
+    {
+      "label": "byte",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Byte"
+      },
+      "kind": "TypeParameter",
+      "insertText": "byte"
+    },
+    {
+      "label": "error",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Error"
+      },
+      "kind": "Event",
+      "insertText": "error"
+    },
+    {
+      "label": "json",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Json"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json"
+    },
+    {
+      "label": "any",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Any"
+      },
+      "kind": "TypeParameter",
+      "insertText": "any"
+    },
+    {
+      "label": "anydata",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Anydata"
+      },
+      "kind": "TypeParameter",
+      "insertText": "anydata"
+    },
+    {
+      "label": "function",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Function"
+      },
+      "kind": "TypeParameter",
+      "insertText": "function"
+    },
+    {
+      "label": "future",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Future"
+      },
+      "kind": "TypeParameter",
+      "insertText": "future"
+    },
+    {
+      "label": "typedesc",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Typedesc"
+      },
+      "kind": "TypeParameter",
+      "insertText": "typedesc"
+    },
+    {
+      "label": "handle",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Handle"
+      },
+      "kind": "TypeParameter",
+      "insertText": "handle"
+    },
+    {
+      "label": "stream",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Stream"
+      },
+      "kind": "TypeParameter",
+      "insertText": "stream"
+    },
+    {
+      "label": "never",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Never"
+      },
+      "kind": "TypeParameter",
+      "insertText": "never"
+    },
+    {
+      "label": "readonly",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Readonly"
+      },
+      "kind": "TypeParameter",
+      "insertText": "readonly"
+    }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
@@ -1,0 +1,349 @@
+{
+  "description": "",
+  "source": "graphql",
+  "position": {
+    "line": 16,
+    "offset": 0
+  },
+  "completions": [
+    {
+      "label": "Profile",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Object"
+      },
+      "kind": "Interface",
+      "insertText": "Profile"
+    },
+    {
+      "label": "AbstractProfile",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "AbstractProfile"
+    },
+    {
+      "label": "Address",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Address"
+    },
+    {
+      "label": "UserName",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "UserName"
+    },
+    {
+      "label": "User",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "User record type\nSimple record type with docs, anonymous field types (union, record)"
+      },
+      "insertText": "User"
+    },
+    {
+      "label": "City",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "City"
+    },
+    {
+      "label": "UserAddress",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Record type with a rest field"
+      },
+      "insertText": "UserAddress"
+    },
+    {
+      "label": "TimeSheet",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Array"
+      },
+      "kind": "TypeParameter",
+      "insertText": "TimeSheet"
+    },
+    {
+      "label": "ApartmentAddress",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Record type with a anonymous rest field"
+      },
+      "insertText": "ApartmentAddress"
+    },
+    {
+      "label": "FooApartmentAddress",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Record type with default values"
+      },
+      "insertText": "FooApartmentAddress"
+    },
+    {
+      "label": "UserAsArrays",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Record type with array field type"
+      },
+      "insertText": "UserAsArrays"
+    },
+    {
+      "label": "Employee",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Employee"
+    },
+    {
+      "label": "SubjectArea",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "enum"
+      },
+      "kind": "Enum",
+      "insertText": "SubjectArea"
+    },
+    {
+      "label": "UserRole",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "enum"
+      },
+      "kind": "Enum",
+      "insertText": "UserRole"
+    },
+    {
+      "label": "AddressType",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "enum"
+      },
+      "kind": "Enum",
+      "insertText": "AddressType"
+    },
+    {
+      "label": "Teacher",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Class"
+      },
+      "kind": "Interface",
+      "insertText": "Teacher"
+    },
+    {
+      "label": "Student",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Class"
+      },
+      "kind": "Interface",
+      "insertText": "Student"
+    },
+    {
+      "label": "UserProfile",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Class"
+      },
+      "kind": "Interface",
+      "insertText": "UserProfile"
+    },
+    {
+      "label": "string",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "String"
+      },
+      "kind": "TypeParameter",
+      "insertText": "string"
+    },
+    {
+      "label": "boolean",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Boolean"
+      },
+      "kind": "TypeParameter",
+      "insertText": "boolean"
+    },
+    {
+      "label": "int",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Int"
+      },
+      "kind": "TypeParameter",
+      "insertText": "int"
+    },
+    {
+      "label": "float",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Float"
+      },
+      "kind": "TypeParameter",
+      "insertText": "float"
+    },
+    {
+      "label": "decimal",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Decimal"
+      },
+      "kind": "TypeParameter",
+      "insertText": "decimal"
+    },
+    {
+      "label": "xml",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Xml"
+      },
+      "kind": "TypeParameter",
+      "insertText": "xml"
+    },
+    {
+      "label": "byte",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Byte"
+      },
+      "kind": "TypeParameter",
+      "insertText": "byte"
+    },
+    {
+      "label": "error",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Error"
+      },
+      "kind": "Event",
+      "insertText": "error"
+    },
+    {
+      "label": "json",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Json"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json"
+    },
+    {
+      "label": "any",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Any"
+      },
+      "kind": "TypeParameter",
+      "insertText": "any"
+    },
+    {
+      "label": "anydata",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Anydata"
+      },
+      "kind": "TypeParameter",
+      "insertText": "anydata"
+    },
+    {
+      "label": "function",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Function"
+      },
+      "kind": "TypeParameter",
+      "insertText": "function"
+    },
+    {
+      "label": "future",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Future"
+      },
+      "kind": "TypeParameter",
+      "insertText": "future"
+    },
+    {
+      "label": "typedesc",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Typedesc"
+      },
+      "kind": "TypeParameter",
+      "insertText": "typedesc"
+    },
+    {
+      "label": "handle",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Handle"
+      },
+      "kind": "TypeParameter",
+      "insertText": "handle"
+    },
+    {
+      "label": "stream",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Stream"
+      },
+      "kind": "TypeParameter",
+      "insertText": "stream"
+    },
+    {
+      "label": "never",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Never"
+      },
+      "kind": "TypeParameter",
+      "insertText": "never"
+    },
+    {
+      "label": "readonly",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Readonly"
+      },
+      "kind": "TypeParameter",
+      "insertText": "readonly"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/data_mapper/types.bal
@@ -1,3 +1,7 @@
+# Represents a geographical location.
+#
+# + city - The name of the city
+# + country - The name of the country
 type Location record {|
     string city;
     string country;

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/Ballerina.toml
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/Ballerina.toml
@@ -1,0 +1,8 @@
+[package]
+org = "testorg"
+name = "test_pack2"
+version = "0.1.0"
+distribution = "2201.11.0"
+
+[build-options]
+observabilityIncluded = true

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/graphql_class.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/graphql_class.bal
@@ -1,0 +1,50 @@
+import ballerina/graphql;
+
+type Profile distinct service object {
+    resource function get name() returns string;
+};
+
+distinct service class Teacher {
+    *Profile;
+
+    private string name;
+    private final string subject;
+
+    function init(string name, string subject) {
+        self.name = name;
+        self.subject = subject;
+    }
+
+    resource function get name() returns string {
+        return self.name;
+    }
+
+    resource function get subject() returns string {
+        return self.subject;
+    }
+
+    resource function get profile() returns Profile {
+        return self;
+    }
+}
+
+distinct service class Student {
+    *Profile;
+
+    private string name;
+
+    function init(string name) {
+        self.name = name;
+    }
+
+    resource function get name() returns string {
+        return "Jesse Pinkman";
+    }
+}
+
+service /graphql/api on new graphql:Listener(9090) {
+
+    resource function get profiles() returns Profile[] {
+        return [new Teacher("Walter White", "Chemistry"), new Student("Jesse Pinkman")];
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/graphql_service.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/graphql_service.bal
@@ -1,0 +1,59 @@
+import ballerina/graphql;
+
+public type AbstractProfile record {|
+    string name;
+    int age;
+    Address address;
+|};
+
+type UserName record {|
+    string value;
+|};
+
+service class UserProfile {
+    private final string name;
+    private final int age;
+
+    function init(string name, int age) {
+        self.name = name;
+        self.age = age;
+    }
+
+    resource function get name() returns string {
+        return self.name;
+    }
+    resource function get age() returns int {
+        return self.age;
+    }
+    resource function get isAdult() returns boolean {
+        return self.age > 21;
+    }
+}
+
+public type Address record {|
+    string number;
+    string street;
+    string city;
+|};
+
+service /graphql on new graphql:Listener(9090) {
+    resource function get profile21() returns AbstractProfile {
+        return {
+            name: "Walter White",
+            age: 51,
+            address: {
+                number: "308",
+                street: "Negra Arroyo Lane",
+                city: "Albuquerque"
+            }
+        };
+    }
+
+    resource function get profile() returns UserProfile {
+        return new ("Walter White", 51);
+    }
+
+    remote function updateName(UserName userName) returns UserProfile {
+        return new (userName.value, 51);
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/main.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/main.bal
@@ -1,0 +1,2 @@
+public function main() {
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/records.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/records.bal
@@ -1,0 +1,52 @@
+import ballerina/time;
+
+# User record type
+# Simple record type with docs, anonymous field types (union, record)
+type User record {
+    # Name of the employee
+    string name;
+    # Age of the employee
+    int age;
+    # Union of of type-refs and a built-in type
+    xml|City|UserAddress address;
+    # Anonymous nested record type
+    record {|int iA; record {|int iiA;|} iB;|} field1;
+};
+
+type TimeSheet time:Utc[][];
+
+type City record {|
+    string city;
+    string country;
+|};
+
+# Record type with a rest field
+type UserAddress record {|
+    *City;
+    # Union of built-in types
+    string|int no;
+    string street;
+    string...;
+|};
+
+# Record type with a anonymous rest field
+type ApartmentAddress record {|
+    *City;
+    string apartmentName;
+    record {|int houseNo; string floor;|}...;
+|};
+
+# Record type with default values
+type FooApartmentAddress record {|
+    *City;
+    string apartmentName = "Foo";
+    City cityCountry = {country: "New York", city: "USA"};
+    record {|int houseNo = 10; string floor = "1st";|}...;
+|};
+
+# Record type with array field type
+type UserAsArrays record {
+    string[] names;
+    int[] ages;
+    City[] addresses;
+};

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/types.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/source/graphql/types.bal
@@ -1,0 +1,23 @@
+type Employee record {|
+    string name;
+    int id;
+|};
+
+enum SubjectArea {
+    CHEMISTRY,
+    PHYSICS,
+    BIOLOGY,
+    MATHEMATICS
+}
+
+enum UserRole {
+    TEACHER,
+    STUDENT,
+    ADMIN
+}
+
+enum AddressType {
+    RESIDENTIAL,
+    BUSINESS,
+    SCHOOL
+}


### PR DESCRIPTION
## Purpose

$title with the following changes:

- Instead of returning only type names, it now provides full CompletionItem objects containing details like kind, documentation, and insert text.
- We are using the `TypeCompletionItemBuilder` in the language-server core to generate the type completion item. This should be refactored later to reuse the implementation.
- Extended the completions to include enums and classes.