### PR TITLE
Consider the type constraint when providing the type completions

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -20,7 +20,11 @@ package io.ballerina.flowmodelgenerator.core;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.Types;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.EnumSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.types.TypeKind;
 import org.eclipse.lsp4j.CompletionItem;
@@ -41,83 +45,131 @@ import java.util.stream.Collectors;
  */
 public class TypesGenerator {
 
-    private final Map<String, TypeSymbol> builtinTypeSymbols;
-    private final Map<String, CompletionItem> builtinTypeCompletionItems;
+    private final Map<String, TypeSymbol> typeSymbolMap;
+    private final Map<TypeSymbol, CompletionItem> completionItemMap;
+    private final Map<TypeSymbol, List<CompletionItem>> subtypeItemsMap;
 
     private static final String PRIMITIVE_TYPE = "Primitive";
     private static final String USER_DEFINED_TYPE = "User-Defined";
     private static final List<SymbolKind> TYPE_SYMBOL_KINDS =
             List.of(SymbolKind.TYPE_DEFINITION, SymbolKind.CLASS, SymbolKind.ENUM);
 
-    // Builtin type names
-    public static final String TYPE_STRING = TypeKind.STRING.typeName();
+    // Basic simple types
     public static final String TYPE_BOOLEAN = TypeKind.BOOLEAN.typeName();
-    public static final String TYPE_INT = TypeKind.INT.typeName();
-    public static final String TYPE_FLOAT = TypeKind.FLOAT.typeName();
     public static final String TYPE_DECIMAL = TypeKind.DECIMAL.typeName();
+    public static final String TYPE_FLOAT = TypeKind.FLOAT.typeName();
+    public static final String TYPE_INT = TypeKind.INT.typeName();
+
+    // Basic sequence types
+    public static final String TYPE_STRING = TypeKind.STRING.typeName();
     public static final String TYPE_XML = TypeKind.XML.typeName();
-    public static final String TYPE_BYTE = TypeKind.BYTE.typeName();
+
+    // Basic behavioral
     public static final String TYPE_ERROR = TypeKind.ERROR.typeName();
-    public static final String TYPE_JSON = TypeKind.JSON.typeName();
-    public static final String TYPE_ANY = TypeKind.ANY.typeName();
-    public static final String TYPE_ANYDATA = TypeKind.ANYDATA.typeName();
     public static final String TYPE_FUNCTION = TypeKind.FUNCTION.typeName();
     public static final String TYPE_FUTURE = TypeKind.FUTURE.typeName();
-    public static final String TYPE_TYPEDESC = TypeKind.TYPEDESC.typeName();
     public static final String TYPE_HANDLE = TypeKind.HANDLE.typeName();
     public static final String TYPE_STREAM = TypeKind.STREAM.typeName();
+    public static final String TYPE_TYPEDESC = TypeKind.TYPEDESC.typeName();
+
+    // Other
+    public static final String TYPE_ANY = TypeKind.ANY.typeName();
+    public static final String TYPE_ANYDATA = TypeKind.ANYDATA.typeName();
+    public static final String TYPE_BYTE = TypeKind.BYTE.typeName();
+    public static final String TYPE_JSON = TypeKind.JSON.typeName();
     public static final String TYPE_NEVER = TypeKind.NEVER.typeName();
     public static final String TYPE_READONLY = TypeKind.READONLY.typeName();
+    public static final String TYPE_RECORD = TypeKind.RECORD.typeName();
 
     private TypesGenerator() {
-        this.builtinTypeSymbols = new LinkedHashMap<>();
-        this.builtinTypeCompletionItems = new LinkedHashMap<>();
+        this.typeSymbolMap = new LinkedHashMap<>();
+        this.completionItemMap = new LinkedHashMap<>();
+        this.subtypeItemsMap = new LinkedHashMap<>();
     }
 
-    public Either<List<CompletionItem>, CompletionList> getTypes(SemanticModel semanticModel) {
-        List<CompletionItem> completionItems = semanticModel.moduleSymbols().parallelStream()
-                .filter(symbol -> TYPE_SYMBOL_KINDS.contains(symbol.kind()))
-                .map(symbol -> TypeCompletionItemBuilder.build(symbol, symbol.getName().orElse(""), USER_DEFINED_TYPE))
-                .collect(Collectors.toCollection(ArrayList::new));
+    public Either<List<CompletionItem>, CompletionList> getTypes(SemanticModel semanticModel, String typeConstraint) {
+        // Get the symbol of the type constraint
         initializeBuiltinTypes(semanticModel);
-        completionItems.addAll(builtinTypeCompletionItems.values());
+        TypeSymbol typeSymbol = typeSymbolMap.get(typeConstraint);
+
+        // If the symbol not found, return all the completions
+        if (typeSymbol == null) {
+            List<CompletionItem> completionItems = semanticModel.moduleSymbols().parallelStream()
+                    .filter(symbol -> TYPE_SYMBOL_KINDS.contains(symbol.kind()))
+                    .map(symbol -> TypeCompletionItemBuilder.build(symbol, symbol.getName().orElse(""),
+                            USER_DEFINED_TYPE))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            completionItems.addAll(completionItemMap.values());
+            return Either.forLeft(completionItems);
+        }
+
+        // Get the filtered type completions
+        List<CompletionItem> completionItems = semanticModel.moduleSymbols().parallelStream()
+                .filter(symbol -> isSubtype(typeSymbol, symbol))
+                .map(symbol -> TypeCompletionItemBuilder.build(symbol, symbol.getName().orElse(""),
+                        USER_DEFINED_TYPE))
+                .collect(Collectors.toCollection(ArrayList::new));
+        completionItems.addAll(subtypeItemsMap.get(typeSymbol));
         return Either.forLeft(completionItems);
+    }
+
+    private static boolean isSubtype(TypeSymbol parentSymbol, Symbol childSymbol) {
+        TypeSymbol childTypeSymbol = switch (childSymbol.kind()) {
+            case TYPE_DEFINITION -> ((TypeDefinitionSymbol) childSymbol).typeDescriptor();
+            case CLASS -> ((ClassSymbol) childSymbol);
+            case ENUM -> ((EnumSymbol) childSymbol).typeDescriptor();
+            default -> null;
+        };
+        if (childTypeSymbol == null) {
+            return false;
+        }
+        return childTypeSymbol.subtypeOf(parentSymbol);
     }
 
     public Optional<TypeSymbol> getTypeSymbol(SemanticModel semanticModel, String typeName) {
         initializeBuiltinTypes(semanticModel);
-        return Optional.ofNullable(builtinTypeSymbols.get(typeName));
+        return Optional.ofNullable(typeSymbolMap.get(typeName));
     }
 
     private void initializeBuiltinTypes(SemanticModel semanticModel) {
-        if (!builtinTypeSymbols.isEmpty()) {
+        if (!typeSymbolMap.isEmpty()) {
             return;
         }
 
         // Obtain the type symbols for the builtin types
         Types types = semanticModel.types();
-        builtinTypeSymbols.put(TYPE_STRING, types.STRING);
-        builtinTypeSymbols.put(TYPE_BOOLEAN, types.BOOLEAN);
-        builtinTypeSymbols.put(TYPE_INT, types.INT);
-        builtinTypeSymbols.put(TYPE_FLOAT, types.FLOAT);
-        builtinTypeSymbols.put(TYPE_DECIMAL, types.DECIMAL);
-        builtinTypeSymbols.put(TYPE_XML, types.XML);
-        builtinTypeSymbols.put(TYPE_BYTE, types.BYTE);
-        builtinTypeSymbols.put(TYPE_ERROR, types.ERROR);
-        builtinTypeSymbols.put(TYPE_JSON, types.JSON);
-        builtinTypeSymbols.put(TYPE_ANY, types.ANY);
-        builtinTypeSymbols.put(TYPE_ANYDATA, types.ANYDATA);
-        builtinTypeSymbols.put(TYPE_FUNCTION, types.FUNCTION);
-        builtinTypeSymbols.put(TYPE_FUTURE, types.FUTURE);
-        builtinTypeSymbols.put(TYPE_TYPEDESC, types.TYPEDESC);
-        builtinTypeSymbols.put(TYPE_HANDLE, types.HANDLE);
-        builtinTypeSymbols.put(TYPE_STREAM, types.STREAM);
-        builtinTypeSymbols.put(TYPE_NEVER, types.NEVER);
-        builtinTypeSymbols.put(TYPE_READONLY, types.READONLY);
+        typeSymbolMap.put(TYPE_STRING, types.STRING);
+        typeSymbolMap.put(TYPE_BOOLEAN, types.BOOLEAN);
+        typeSymbolMap.put(TYPE_INT, types.INT);
+        typeSymbolMap.put(TYPE_FLOAT, types.FLOAT);
+        typeSymbolMap.put(TYPE_DECIMAL, types.DECIMAL);
+        typeSymbolMap.put(TYPE_XML, types.XML);
+        typeSymbolMap.put(TYPE_BYTE, types.BYTE);
+        typeSymbolMap.put(TYPE_ERROR, types.ERROR);
+        typeSymbolMap.put(TYPE_JSON, types.JSON);
+        typeSymbolMap.put(TYPE_ANY, types.ANY);
+        typeSymbolMap.put(TYPE_ANYDATA, types.ANYDATA);
+        typeSymbolMap.put(TYPE_FUNCTION, types.FUNCTION);
+        typeSymbolMap.put(TYPE_FUTURE, types.FUTURE);
+        typeSymbolMap.put(TYPE_TYPEDESC, types.TYPEDESC);
+        typeSymbolMap.put(TYPE_HANDLE, types.HANDLE);
+        typeSymbolMap.put(TYPE_STREAM, types.STREAM);
+        typeSymbolMap.put(TYPE_NEVER, types.NEVER);
+        typeSymbolMap.put(TYPE_READONLY, types.READONLY);
+        typeSymbolMap.put(TYPE_RECORD, types.builder().RECORD_TYPE.withRestField(types.ANYDATA).build());
 
         // Build the completion items for the builtin types
-        builtinTypeSymbols.forEach((name, symbol) -> builtinTypeCompletionItems.put(name,
+        typeSymbolMap.forEach((name, symbol) -> completionItemMap.put(symbol,
                 TypeCompletionItemBuilder.build(symbol, name, PRIMITIVE_TYPE)));
+
+        // Build the subtype items for the builtin types
+        typeSymbolMap.forEach((name, symbol) -> {
+            List<CompletionItem> completionsList = typeSymbolMap.values().parallelStream()
+                    .filter(typeSymbol -> typeSymbol.subtypeOf(symbol))
+                    .map(completionItemMap::get)
+                    .toList();
+            subtypeItemsMap.put(symbol, completionsList);
+        });
     }
 
     public static TypesGenerator getInstance() {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -77,7 +77,6 @@ public class TypesGenerator {
     public static final String TYPE_ANYDATA = TypeKind.ANYDATA.typeName();
     public static final String TYPE_BYTE = TypeKind.BYTE.typeName();
     public static final String TYPE_JSON = TypeKind.JSON.typeName();
-    public static final String TYPE_NEVER = TypeKind.NEVER.typeName();
     public static final String TYPE_READONLY = TypeKind.READONLY.typeName();
     public static final String TYPE_RECORD = TypeKind.RECORD.typeName();
 
@@ -154,7 +153,6 @@ public class TypesGenerator {
         typeSymbolMap.put(TYPE_TYPEDESC, types.TYPEDESC);
         typeSymbolMap.put(TYPE_HANDLE, types.HANDLE);
         typeSymbolMap.put(TYPE_STREAM, types.STREAM);
-        typeSymbolMap.put(TYPE_NEVER, types.NEVER);
         typeSymbolMap.put(TYPE_READONLY, types.READONLY);
         typeSymbolMap.put(TYPE_RECORD, types.builder().RECORD_TYPE.withRestField(types.ANYDATA).build());
 

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorService.java
@@ -31,6 +31,7 @@ import io.ballerina.flowmodelgenerator.core.model.Codedata;
 import io.ballerina.flowmodelgenerator.extension.request.ExpressionEditorCompletionRequest;
 import io.ballerina.flowmodelgenerator.extension.request.ExpressionEditorDiagnosticsRequest;
 import io.ballerina.flowmodelgenerator.extension.request.ExpressionEditorSignatureRequest;
+import io.ballerina.flowmodelgenerator.extension.request.ExpressionEditorTypesRequest;
 import io.ballerina.flowmodelgenerator.extension.request.FunctionCallTemplateRequest;
 import io.ballerina.flowmodelgenerator.extension.request.ImportModuleRequest;
 import io.ballerina.flowmodelgenerator.extension.request.VisibleVariableTypeRequest;
@@ -102,14 +103,14 @@ public class ExpressionEditorService implements ExtendedLanguageServerService {
     }
 
     @JsonRequest
-    public CompletableFuture<Either<List<CompletionItem>, CompletionList>> types(VisibleVariableTypeRequest request) {
+    public CompletableFuture<Either<List<CompletionItem>, CompletionList>> types(ExpressionEditorTypesRequest request) {
         return CompletableFuture.supplyAsync(() -> {
             try {
                 Path filePath = Path.of(request.filePath());
                 Project project = this.workspaceManagerProxy.get().loadProject(filePath);
                 SemanticModel semanticModel = this.workspaceManagerProxy.get().semanticModel(filePath).orElseGet(
                         () -> project.currentPackage().getDefaultModule().getCompilation().getSemanticModel());
-                return TypesGenerator.getInstance().getTypes(semanticModel);
+                return TypesGenerator.getInstance().getTypes(semanticModel, request.typeConstraint());
             } catch (Throwable e) {
                 return Either.forRight(new CompletionList());
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/ExpressionEditorTypesRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/ExpressionEditorTypesRequest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.extension.request;
+
+/**
+ * Record representing a request for expression editor types.
+ *
+ * @param filePath The path to the file being processed
+ * @param typeConstraint The type constraint to filter out the completions
+ * @since 2.0.0
+ */
+public record ExpressionEditorTypesRequest(String filePath, String typeConstraint) {
+
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorTypesTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorTypesTest.java
@@ -19,9 +19,8 @@
 package io.ballerina.flowmodelgenerator.extension;
 
 import com.google.gson.JsonObject;
-import io.ballerina.flowmodelgenerator.extension.request.VisibleVariableTypeRequest;
+import io.ballerina.flowmodelgenerator.extension.request.ExpressionEditorTypesRequest;
 import io.ballerina.modelgenerator.commons.AbstractLSTest;
-import io.ballerina.tools.text.LinePosition;
 import org.eclipse.lsp4j.CompletionItem;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -43,15 +42,15 @@ public class ExpressionEditorTypesTest extends AbstractLSTest {
         Path configJsonPath = configDir.resolve(config);
         TestConfig testConfig = gson.fromJson(Files.newBufferedReader(configJsonPath), TestConfig.class);
 
-        VisibleVariableTypeRequest request =
-                new VisibleVariableTypeRequest(getSourcePath(testConfig.source()), testConfig.position());
+        ExpressionEditorTypesRequest request =
+                new ExpressionEditorTypesRequest(getSourcePath(testConfig.source()), testConfig.typeConstraint());
         JsonObject response = getResponse(request);
 
         List<CompletionItem> actualCompletions = gson.fromJson(response.get("left").getAsJsonArray(),
                 ExpressionEditorCompletionTest.COMPLETION_RESPONSE_TYPE);
         if (!assertArray("completions", actualCompletions, testConfig.completions())) {
             TestConfig updatedConfig = new TestConfig(testConfig.description(), testConfig.source(),
-                    testConfig.position(), actualCompletions);
+                    testConfig.typeConstraint(), actualCompletions);
 //            updateConfig(configJsonPath, updatedConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }
@@ -77,7 +76,7 @@ public class ExpressionEditorTypesTest extends AbstractLSTest {
         return "expressionEditor";
     }
 
-    private record TestConfig(String description, String source, LinePosition position,
+    private record TestConfig(String description, String source, String typeConstraint,
                               List<CompletionItem> completions) {
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
@@ -213,15 +213,6 @@
       "insertText": "stream"
     },
     {
-      "label": "never",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Never"
-      },
-      "kind": "TypeParameter",
-      "insertText": "never"
-    },
-    {
       "label": "readonly",
       "labelDetails": {
         "detail": "Primitive",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
@@ -1,10 +1,7 @@
 {
   "description": "",
   "source": "data_mapper/service.bal",
-  "position": {
-    "line": 14,
-    "offset": 0
-  },
+  "typeConstraint": "record",
   "completions": [
     {
       "label": "Input",
@@ -73,150 +70,6 @@
       "insertText": "Admission"
     },
     {
-      "label": "string",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "String"
-      },
-      "kind": "TypeParameter",
-      "insertText": "string"
-    },
-    {
-      "label": "boolean",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Boolean"
-      },
-      "kind": "TypeParameter",
-      "insertText": "boolean"
-    },
-    {
-      "label": "int",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Int"
-      },
-      "kind": "TypeParameter",
-      "insertText": "int"
-    },
-    {
-      "label": "float",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Float"
-      },
-      "kind": "TypeParameter",
-      "insertText": "float"
-    },
-    {
-      "label": "decimal",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Decimal"
-      },
-      "kind": "TypeParameter",
-      "insertText": "decimal"
-    },
-    {
-      "label": "xml",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Xml"
-      },
-      "kind": "TypeParameter",
-      "insertText": "xml"
-    },
-    {
-      "label": "byte",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Byte"
-      },
-      "kind": "TypeParameter",
-      "insertText": "byte"
-    },
-    {
-      "label": "error",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Error"
-      },
-      "kind": "Event",
-      "insertText": "error"
-    },
-    {
-      "label": "json",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Json"
-      },
-      "kind": "TypeParameter",
-      "insertText": "json"
-    },
-    {
-      "label": "any",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Any"
-      },
-      "kind": "TypeParameter",
-      "insertText": "any"
-    },
-    {
-      "label": "anydata",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Anydata"
-      },
-      "kind": "TypeParameter",
-      "insertText": "anydata"
-    },
-    {
-      "label": "function",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Function"
-      },
-      "kind": "TypeParameter",
-      "insertText": "function"
-    },
-    {
-      "label": "future",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Future"
-      },
-      "kind": "TypeParameter",
-      "insertText": "future"
-    },
-    {
-      "label": "typedesc",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Typedesc"
-      },
-      "kind": "TypeParameter",
-      "insertText": "typedesc"
-    },
-    {
-      "label": "handle",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Handle"
-      },
-      "kind": "TypeParameter",
-      "insertText": "handle"
-    },
-    {
-      "label": "stream",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Stream"
-      },
-      "kind": "TypeParameter",
-      "insertText": "stream"
-    },
-    {
       "label": "never",
       "labelDetails": {
         "detail": "Primitive",
@@ -226,13 +79,13 @@
       "insertText": "never"
     },
     {
-      "label": "readonly",
+      "label": "record",
       "labelDetails": {
         "detail": "Primitive",
-        "description": "Readonly"
+        "description": "Record"
       },
-      "kind": "TypeParameter",
-      "insertText": "readonly"
+      "kind": "Struct",
+      "insertText": "record"
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
@@ -70,15 +70,6 @@
       "insertText": "Admission"
     },
     {
-      "label": "never",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Never"
-      },
-      "kind": "TypeParameter",
-      "insertText": "never"
-    },
-    {
       "label": "record",
       "labelDetails": {
         "detail": "Primitive",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config3.json
@@ -1,6 +1,7 @@
 {
   "description": "",
   "source": "data_mapper",
+  "typeConstraint": "record",
   "completions": [
     {
       "label": "Input",
@@ -69,150 +70,6 @@
       "insertText": "Admission"
     },
     {
-      "label": "string",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "String"
-      },
-      "kind": "TypeParameter",
-      "insertText": "string"
-    },
-    {
-      "label": "boolean",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Boolean"
-      },
-      "kind": "TypeParameter",
-      "insertText": "boolean"
-    },
-    {
-      "label": "int",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Int"
-      },
-      "kind": "TypeParameter",
-      "insertText": "int"
-    },
-    {
-      "label": "float",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Float"
-      },
-      "kind": "TypeParameter",
-      "insertText": "float"
-    },
-    {
-      "label": "decimal",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Decimal"
-      },
-      "kind": "TypeParameter",
-      "insertText": "decimal"
-    },
-    {
-      "label": "xml",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Xml"
-      },
-      "kind": "TypeParameter",
-      "insertText": "xml"
-    },
-    {
-      "label": "byte",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Byte"
-      },
-      "kind": "TypeParameter",
-      "insertText": "byte"
-    },
-    {
-      "label": "error",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Error"
-      },
-      "kind": "Event",
-      "insertText": "error"
-    },
-    {
-      "label": "json",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Json"
-      },
-      "kind": "TypeParameter",
-      "insertText": "json"
-    },
-    {
-      "label": "any",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Any"
-      },
-      "kind": "TypeParameter",
-      "insertText": "any"
-    },
-    {
-      "label": "anydata",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Anydata"
-      },
-      "kind": "TypeParameter",
-      "insertText": "anydata"
-    },
-    {
-      "label": "function",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Function"
-      },
-      "kind": "TypeParameter",
-      "insertText": "function"
-    },
-    {
-      "label": "future",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Future"
-      },
-      "kind": "TypeParameter",
-      "insertText": "future"
-    },
-    {
-      "label": "typedesc",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Typedesc"
-      },
-      "kind": "TypeParameter",
-      "insertText": "typedesc"
-    },
-    {
-      "label": "handle",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Handle"
-      },
-      "kind": "TypeParameter",
-      "insertText": "handle"
-    },
-    {
-      "label": "stream",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Stream"
-      },
-      "kind": "TypeParameter",
-      "insertText": "stream"
-    },
-    {
       "label": "never",
       "labelDetails": {
         "detail": "Primitive",
@@ -222,13 +79,13 @@
       "insertText": "never"
     },
     {
-      "label": "readonly",
+      "label": "record",
       "labelDetails": {
         "detail": "Primitive",
-        "description": "Readonly"
+        "description": "Record"
       },
-      "kind": "TypeParameter",
-      "insertText": "readonly"
+      "kind": "Struct",
+      "insertText": "record"
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config3.json
@@ -70,15 +70,6 @@
       "insertText": "Admission"
     },
     {
-      "label": "never",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Never"
-      },
-      "kind": "TypeParameter",
-      "insertText": "never"
-    },
-    {
       "label": "record",
       "labelDetails": {
         "detail": "Primitive",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
@@ -324,15 +324,6 @@
       "insertText": "stream"
     },
     {
-      "label": "never",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Never"
-      },
-      "kind": "TypeParameter",
-      "insertText": "never"
-    },
-    {
       "label": "readonly",
       "labelDetails": {
         "detail": "Primitive",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
@@ -1,10 +1,6 @@
 {
   "description": "",
   "source": "graphql",
-  "position": {
-    "line": 16,
-    "offset": 0
-  },
   "completions": [
     {
       "label": "Profile",
@@ -344,6 +340,15 @@
       },
       "kind": "TypeParameter",
       "insertText": "readonly"
+    },
+    {
+      "label": "record",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "record"
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
@@ -1,6 +1,7 @@
 {
   "description": "",
   "source": "data_mapper/main.bal",
+  "typeConstraint": "anydata",
   "completions": [
     {
       "label": "Input",
@@ -132,15 +133,6 @@
       "insertText": "byte"
     },
     {
-      "label": "error",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Error"
-      },
-      "kind": "Event",
-      "insertText": "error"
-    },
-    {
       "label": "json",
       "labelDetails": {
         "detail": "Primitive",
@@ -148,15 +140,6 @@
       },
       "kind": "TypeParameter",
       "insertText": "json"
-    },
-    {
-      "label": "any",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Any"
-      },
-      "kind": "TypeParameter",
-      "insertText": "any"
     },
     {
       "label": "anydata",
@@ -168,51 +151,6 @@
       "insertText": "anydata"
     },
     {
-      "label": "function",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Function"
-      },
-      "kind": "TypeParameter",
-      "insertText": "function"
-    },
-    {
-      "label": "future",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Future"
-      },
-      "kind": "TypeParameter",
-      "insertText": "future"
-    },
-    {
-      "label": "typedesc",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Typedesc"
-      },
-      "kind": "TypeParameter",
-      "insertText": "typedesc"
-    },
-    {
-      "label": "handle",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Handle"
-      },
-      "kind": "TypeParameter",
-      "insertText": "handle"
-    },
-    {
-      "label": "stream",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Stream"
-      },
-      "kind": "TypeParameter",
-      "insertText": "stream"
-    },
-    {
       "label": "never",
       "labelDetails": {
         "detail": "Primitive",
@@ -220,15 +158,6 @@
       },
       "kind": "TypeParameter",
       "insertText": "never"
-    },
-    {
-      "label": "readonly",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Readonly"
-      },
-      "kind": "TypeParameter",
-      "insertText": "readonly"
     },
     {
       "label": "record",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
@@ -151,15 +151,6 @@
       "insertText": "anydata"
     },
     {
-      "label": "never",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Never"
-      },
-      "kind": "TypeParameter",
-      "insertText": "never"
-    },
-    {
       "label": "record",
       "labelDetails": {
         "detail": "Primitive",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config6.json
@@ -104,15 +104,6 @@
       },
       "kind": "TypeParameter",
       "insertText": "json"
-    },
-    {
-      "label": "never",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Never"
-      },
-      "kind": "TypeParameter",
-      "insertText": "never"
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config6.json
@@ -1,0 +1,118 @@
+{
+  "description": "",
+  "source": "data_mapper/main.bal",
+  "typeConstraint": "json",
+  "completions": [
+    {
+      "label": "Location",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "documentation": {
+        "left": "Represents a geographical location.\n"
+      },
+      "insertText": "Location"
+    },
+    {
+      "label": "Address",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Address"
+    },
+    {
+      "label": "Employee",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Employee"
+    },
+    {
+      "label": "Person",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "Person"
+    },
+    {
+      "label": "string",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "String"
+      },
+      "kind": "TypeParameter",
+      "insertText": "string"
+    },
+    {
+      "label": "boolean",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Boolean"
+      },
+      "kind": "TypeParameter",
+      "insertText": "boolean"
+    },
+    {
+      "label": "int",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Int"
+      },
+      "kind": "TypeParameter",
+      "insertText": "int"
+    },
+    {
+      "label": "float",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Float"
+      },
+      "kind": "TypeParameter",
+      "insertText": "float"
+    },
+    {
+      "label": "decimal",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Decimal"
+      },
+      "kind": "TypeParameter",
+      "insertText": "decimal"
+    },
+    {
+      "label": "byte",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Byte"
+      },
+      "kind": "TypeParameter",
+      "insertText": "byte"
+    },
+    {
+      "label": "json",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Json"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json"
+    },
+    {
+      "label": "never",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Never"
+      },
+      "kind": "TypeParameter",
+      "insertText": "never"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
@@ -1,6 +1,7 @@
 {
   "description": "",
   "source": "data_mapper/main.bal",
+  "typeConstraint": "any",
   "completions": [
     {
       "label": "Input",
@@ -132,15 +133,6 @@
       "insertText": "byte"
     },
     {
-      "label": "error",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Error"
-      },
-      "kind": "Event",
-      "insertText": "error"
-    },
-    {
       "label": "json",
       "labelDetails": {
         "detail": "Primitive",
@@ -220,15 +212,6 @@
       },
       "kind": "TypeParameter",
       "insertText": "never"
-    },
-    {
-      "label": "readonly",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Readonly"
-      },
-      "kind": "TypeParameter",
-      "insertText": "readonly"
     },
     {
       "label": "record",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
@@ -205,15 +205,6 @@
       "insertText": "stream"
     },
     {
-      "label": "never",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Never"
-      },
-      "kind": "TypeParameter",
-      "insertText": "never"
-    },
-    {
       "label": "record",
       "labelDetails": {
         "detail": "Primitive",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config8.json
@@ -1,0 +1,25 @@
+{
+  "description": "",
+  "source": "data_mapper/main.bal",
+  "typeConstraint": "string",
+  "completions": [
+    {
+      "label": "string",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "String"
+      },
+      "kind": "TypeParameter",
+      "insertText": "string"
+    },
+    {
+      "label": "never",
+      "labelDetails": {
+        "detail": "Primitive",
+        "description": "Never"
+      },
+      "kind": "TypeParameter",
+      "insertText": "never"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config8.json
@@ -11,15 +11,6 @@
       },
       "kind": "TypeParameter",
       "insertText": "string"
-    },
-    {
-      "label": "never",
-      "labelDetails": {
-        "detail": "Primitive",
-        "description": "Never"
-      },
-      "kind": "TypeParameter",
-      "insertText": "never"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
The completions are now filtered based on the type constraint attached to the respective type property in the form field. If there is no type constraint or if the constraint is invalid, all type completions are presented. 

Please note that the type constraint currently only handles built-in types. This means it works for data mapping forms, configurable forms, and dependable types forms. The implementation needs to be extended to support user-defined and module type constraints, which require fetching the type symbol from the semantic model.