### PR TITLE
Remove unused categories from the helper pane

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
@@ -7,6 +7,101 @@
   },
   "visibleTypes": [
     {
+      "name": "Local Variables",
+      "types": [
+        {
+          "name": "address",
+          "type": {
+            "fields": [
+              {
+                "name": "houseNo",
+                "typeName": "string",
+                "optional": false,
+                "defaultable": false,
+                "isRestType": false,
+                "selected": false
+              },
+              {
+                "name": "line1",
+                "typeName": "string",
+                "optional": false,
+                "defaultable": false,
+                "isRestType": false,
+                "selected": false
+              },
+              {
+                "name": "line2",
+                "typeName": "string",
+                "optional": false,
+                "defaultable": false,
+                "isRestType": false,
+                "selected": false
+              },
+              {
+                "name": "city",
+                "typeName": "string",
+                "optional": false,
+                "defaultable": false,
+                "isRestType": false,
+                "selected": false
+              },
+              {
+                "name": "country",
+                "typeName": "string",
+                "optional": false,
+                "defaultable": false,
+                "isRestType": false,
+                "selected": false
+              }
+            ],
+            "hasRestType": false,
+            "name": "Address",
+            "typeName": "record",
+            "optional": false,
+            "typeInfo": {
+              "name": "Address",
+              "orgName": "nipunaf",
+              "moduleName": "new_connection1",
+              "version": "0.1.0"
+            },
+            "defaultable": false,
+            "isRestType": false,
+            "selected": false
+          }
+        },
+        {
+          "name": "w",
+          "type": {
+            "typeName": "boolean",
+            "optional": false,
+            "defaultable": false,
+            "isRestType": false,
+            "selected": false
+          }
+        },
+        {
+          "name": "x",
+          "type": {
+            "typeName": "int",
+            "optional": false,
+            "defaultable": false,
+            "isRestType": false,
+            "selected": false
+          }
+        },
+        {
+          "name": "z",
+          "type": {
+            "typeName": "string",
+            "optional": false,
+            "defaultable": false,
+            "isRestType": false,
+            "selected": false
+          }
+        }
+      ]
+    },
+    {
       "name": "Module Variables",
       "types": [
         {
@@ -247,109 +342,6 @@
           }
         }
       ]
-    },
-    {
-      "name": "Local Variables",
-      "types": [
-        {
-          "name": "address",
-          "type": {
-            "fields": [
-              {
-                "name": "houseNo",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "line1",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "line2",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "city",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "country",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "hasRestType": false,
-            "name": "Address",
-            "typeName": "record",
-            "optional": false,
-            "typeInfo": {
-              "name": "Address",
-              "orgName": "nipunaf",
-              "moduleName": "new_connection1",
-              "version": "0.1.0"
-            },
-            "defaultable": false,
-            "isRestType": false,
-            "selected": false
-          }
-        },
-        {
-          "name": "w",
-          "type": {
-            "typeName": "boolean",
-            "optional": false,
-            "defaultable": false,
-            "isRestType": false,
-            "selected": false
-          }
-        },
-        {
-          "name": "x",
-          "type": {
-            "typeName": "int",
-            "optional": false,
-            "defaultable": false,
-            "isRestType": false,
-            "selected": false
-          }
-        },
-        {
-          "name": "z",
-          "type": {
-            "typeName": "string",
-            "optional": false,
-            "defaultable": false,
-            "isRestType": false,
-            "selected": false
-          }
-        }
-      ]
-    },
-    {
-      "name": "Parameters",
-      "types": []
-    },
-    {
-      "name": "Path Parameters",
-      "types": []
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
@@ -7,6 +7,54 @@
   },
   "visibleTypes": [
     {
+      "name": "Local Variables",
+      "types": [
+        {
+          "name": "localInput",
+          "type": {
+            "fields": [
+              {
+                "name": "name",
+                "typeName": "string",
+                "optional": false,
+                "defaultable": false,
+                "isRestType": false,
+                "selected": false
+              },
+              {
+                "name": "age",
+                "typeName": "int",
+                "optional": false,
+                "defaultable": false,
+                "isRestType": false,
+                "selected": false
+              }
+            ],
+            "hasRestType": true,
+            "restType": {
+              "typeName": "anydata",
+              "optional": false,
+              "defaultable": false,
+              "isRestType": false,
+              "selected": false
+            },
+            "name": "Input",
+            "typeName": "record",
+            "optional": false,
+            "typeInfo": {
+              "name": "Input",
+              "orgName": "nipunaf",
+              "moduleName": "new_connection1",
+              "version": "0.1.0"
+            },
+            "defaultable": false,
+            "isRestType": false,
+            "selected": false
+          }
+        }
+      ]
+    },
+    {
       "name": "Module Variables",
       "types": [
         {
@@ -262,54 +310,6 @@
           "type": {
             "typeName": "int",
             "optional": false,
-            "defaultable": false,
-            "isRestType": false,
-            "selected": false
-          }
-        }
-      ]
-    },
-    {
-      "name": "Local Variables",
-      "types": [
-        {
-          "name": "localInput",
-          "type": {
-            "fields": [
-              {
-                "name": "name",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "age",
-                "typeName": "int",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "hasRestType": true,
-            "restType": {
-              "typeName": "anydata",
-              "optional": false,
-              "defaultable": false,
-              "isRestType": false,
-              "selected": false
-            },
-            "name": "Input",
-            "typeName": "record",
-            "optional": false,
-            "typeInfo": {
-              "name": "Input",
-              "orgName": "nipunaf",
-              "moduleName": "new_connection1",
-              "version": "0.1.0"
-            },
             "defaultable": false,
             "isRestType": false,
             "selected": false


### PR DESCRIPTION
## Purpose
The `visibileVariableTypes` API is modified to ignore empty categories, and only provide results with categories that have at least one item