### PR TITLE
Fix the sanitization of the search match query

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/salesforce.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/search/config/connectors/salesforce.json
@@ -1,0 +1,58 @@
+{
+  "description": "Sample flow model",
+  "kind": "CONNECTOR",
+  "source": "empty.bal",
+  "queryMap": {
+    "q": "salesforce"
+  },
+  "categories": [
+    {
+      "metadata": {
+        "label": "Salesforce Client",
+        "description": "Ballerina Salesforce connector provides the capability to access Salesforce REST API.\nThis connector lets you to perform operations for SObjects, query using SOQL, search using SOSL, and describe SObjects\nand organizational data.",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_salesforce_8.1.0.png"
+      },
+      "codedata": {
+        "node": "NEW_CONNECTION",
+        "org": "ballerinax",
+        "module": "salesforce",
+        "object": "Client",
+        "symbol": "init",
+        "version": "8.1.0"
+      },
+      "enabled": true
+    },
+    {
+      "metadata": {
+        "label": "Pardot Client",
+        "description": "This is a generated connector for [Salesforce Pardot API v5](https://developer.salesforce.com/docs/marketing/pardot/guide/version5overview.html) OpenAPI specification.\nThe version 5 of the Pardot API to read and update a variety of assets and objects, like File and Layout Template objects.",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_salesforce.pardot_1.3.1.png"
+      },
+      "codedata": {
+        "node": "NEW_CONNECTION",
+        "org": "ballerinax",
+        "module": "salesforce.pardot",
+        "object": "Client",
+        "symbol": "init",
+        "version": "1.3.1"
+      },
+      "enabled": true
+    },
+    {
+      "metadata": {
+        "label": "Einstein Client",
+        "description": "This is a generated connector for [Einstein Vision and Einstein Language API](https://metamind.readme.io/reference#predictive-vision-service-api) OpenAPI specification. Allows you to access the Einstein Vision and Einstein Language services via the standard REST API calls. Use the APIs to programmatically work with datasets, labels, examples, models, and predictions.",
+        "icon": "https://bcentral-packageicons.azureedge.net/images/ballerinax_salesforce.einstein_1.3.1.png"
+      },
+      "codedata": {
+        "node": "NEW_CONNECTION",
+        "org": "ballerinax",
+        "module": "salesforce.einstein",
+        "object": "Client",
+        "symbol": "init",
+        "version": "1.3.1"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/SearchDatabaseManager.java
+++ b/model-generator-commons/src/main/java/io/ballerina/modelgenerator/commons/SearchDatabaseManager.java
@@ -479,8 +479,7 @@ public class SearchDatabaseManager {
             return "";
         }
         // Escape quotes and remove special SQLite FTS operators, and only allow alphanumeric characters and spaces
-        return q.replace("\"", "\"\"")
-                .replaceAll("(?i)(UNION|SELECT|FROM|OR|AND|WHERE|MATCH|NEAR|NOT)|[^a-zA-Z0-9\\s\"]", " ")
+        return q.replaceAll("(?i)\\b(UNION|SELECT|FROM|OR|AND|WHERE|MATCH|NEAR|NOT)\\b|[^a-zA-Z0-9\\s]", " ")
                 .trim();
     }
 


### PR DESCRIPTION
## Purpose

Currently, the system drops results when it finds the keyword "or". This change ensures that the word is only matched when it appears as a separate term.