### PR TITLE
Fix several usability issues in service designer

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/type/RecordValueGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/type/RecordValueGenerator.java
@@ -90,12 +90,10 @@ public class RecordValueGenerator {
                         if (memberObj.has("typeName")) {
                             String typeName = memberObj.get("typeName").getAsString();
                             switch (typeName) {
-                                case "record" -> {
-                                    generateRecordValue(memberObj, builder);
-                                }
-                                case "union" -> {
-                                    generateUnionValue(memberObj, builder);
-                                } default -> {
+                                case "record" -> generateRecordValue(memberObj, builder);
+                                case "union" -> generateUnionValue(memberObj, builder);
+                                case "enum" -> generateEnumValue(memberObj, builder);
+                                default -> {
                                     if (memberObj.has("value") &&
                                             !memberObj.get("value").getAsString().isEmpty()) {
                                         builder.append(memberObj.get("value").getAsString());
@@ -142,6 +140,11 @@ public class RecordValueGenerator {
                                 case "union" -> {
                                     StringBuilder sb = new StringBuilder();
                                     generateUnionValue(fieldObj, sb);
+                                    fieldValues.add(fieldObj.get("name").getAsString() + ": " + sb);
+                                }
+                                case "enum" -> {
+                                    StringBuilder sb = new StringBuilder();
+                                    generateEnumValue(fieldObj, sb);
                                     fieldValues.add(fieldObj.get("name").getAsString() + ": " + sb);
                                 }
                                 default -> {
@@ -195,8 +198,7 @@ public class RecordValueGenerator {
             case "table" -> builder.append("table []");
             default -> {
                 switch (typeName) {
-                    case "any", "anydata" -> builder.append("()");
-                    case "json" -> builder.append("{}");
+                    case "any", "anydata", "json" -> builder.append("()");
                     case "xml" -> builder.append("xml ``");
                     case "string" -> builder.append("\"\"");
                     case "string:Char" -> builder.append("\"a\"");

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
@@ -39,7 +39,8 @@ public class ServiceModelGeneratorConstants {
 
     public static final String HTTP_DEFAULT_LISTENER_STMT = LINE_SEPARATOR +
             "listener http:Listener %s = http:getDefaultListener();" + LINE_SEPARATOR;
-    public static final String HTTP_DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use the default HTTP listener (port: 8080)";
+    public static final String HTTP_DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use the default HTTP listener" +
+            " (port: 8080)";
     public static final String HTTP_DEFAULT_LISTENER_VAR_NAME = "httpDefaultListener";
     public static final String HTTP_DEFAULT_LISTENER_EXPR = "http:getDefaultListener()";
 

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
@@ -39,7 +39,7 @@ public class ServiceModelGeneratorConstants {
 
     public static final String HTTP_DEFAULT_LISTENER_STMT = LINE_SEPARATOR +
             "listener http:Listener %s = http:getDefaultListener();" + LINE_SEPARATOR;
-    public static final String HTTP_DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use the default HTTP listener";
+    public static final String HTTP_DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use the default HTTP listener (port: 8080)";
     public static final String HTTP_DEFAULT_LISTENER_VAR_NAME = "httpDefaultListener";
     public static final String HTTP_DEFAULT_LISTENER_EXPR = "http:getDefaultListener()";
 

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorService.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorService.java
@@ -343,8 +343,9 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
                     edits.add(new TextEdit(Utils.toRange(listenerDeclaringLoc), listenerDeclarationStmt));
                 }
 
-                boolean isTcpService = Utils.isTcpService(service.getOrgName(), service.getPackageName());
-                if (isTcpService) {
+                Utils.FunctionAddContext context = Utils.getTriggerAddContext(service.getOrgName(),
+                        service.getPackageName());
+                if (context.equals(Utils.FunctionAddContext.TCP_SERVICE_ADD)) {
                     if (semanticModel == null) {
                         semanticModel = document.get().module().getCompilation().getSemanticModel();
                     }
@@ -354,11 +355,11 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
                 }
 
                 updateFunctionList(service);
-                String serviceDeclaration = getServiceDeclarationNode(service);
+                String serviceDeclaration = getServiceDeclarationNode(service, context);
                 edits.add(new TextEdit(Utils.toRange(lineRange.endLine()),
                         ServiceModelGeneratorConstants.LINE_SEPARATOR + serviceDeclaration));
 
-                if (isTcpService) {
+                if (context.equals(Utils.FunctionAddContext.TCP_SERVICE_ADD)) {
                     String serviceName = service.getProperties().get("returningServiceClass").getValue();
                     String serviceClass = ServiceClassUtil.getTcpConnectionServiceTemplate().formatted(serviceName);
                     edits.add(new TextEdit(Utils.toRange(lineRange.endLine()),
@@ -439,7 +440,8 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
                 LineRange serviceEnd = serviceNode.closeBraceToken().lineRange();
                 List<String> statusCodeResponses = new ArrayList<>();
                 String functionDefinition = ServiceModelGeneratorConstants.LINE_SEPARATOR +
-                        "\t" + getFunction(request.function(), statusCodeResponses, Utils.FunctionBodyKind.DO_BLOCK)
+                        "\t" + getFunction(request.function(), statusCodeResponses, Utils.FunctionBodyKind.DO_BLOCK,
+                        Utils.FunctionAddContext.RESOURCE_ADD)
                         .replace(ServiceModelGeneratorConstants.LINE_SEPARATOR,
                                 ServiceModelGeneratorConstants.LINE_SEPARATOR + "\t")
                         + ServiceModelGeneratorConstants.LINE_SEPARATOR;
@@ -673,7 +675,8 @@ public class ServiceModelGeneratorService implements ExtendedLanguageServerServi
                     functionLineRange = members.get(members.size() - 1).lineRange();
                 }
                 String functionNode = ServiceModelGeneratorConstants.LINE_SEPARATOR + "\t"
-                        + getFunction(request.function(), new ArrayList<>(), Utils.FunctionBodyKind.DO_BLOCK)
+                        + getFunction(request.function(), new ArrayList<>(), Utils.FunctionBodyKind.DO_BLOCK,
+                        Utils.FunctionAddContext.FUNCTION_ADD)
                         .replace(ServiceModelGeneratorConstants.LINE_SEPARATOR,
                                 ServiceModelGeneratorConstants.LINE_SEPARATOR + "\t");
                 edits.add(new TextEdit(Utils.toRange(functionLineRange.endLine()), functionNode));

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Function.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Function.java
@@ -26,6 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static io.ballerina.servicemodelgenerator.extension.util.ServiceClassUtil.ServiceClassContext.GRAPHQL_DIAGRAM;
+import static io.ballerina.servicemodelgenerator.extension.util.ServiceClassUtil.ServiceClassContext.SERVICE_DIAGRAM;
+import static io.ballerina.servicemodelgenerator.extension.util.ServiceClassUtil.ServiceClassContext.TYPE_DIAGRAM;
+
 public class Function {
     private MetaData metadata;
     private List<String> qualifiers;
@@ -61,7 +65,7 @@ public class Function {
         this.codedata = codedata;
     }
 
-    public static Function getNewFunction() {
+    private static Function getNewFunctionModel() {
         return new Function(new MetaData("", ""), new ArrayList<>(),
                 ServiceModelGeneratorConstants.KIND_DEFAULT,
                 new Value(ServiceModelGeneratorConstants.FUNCTION_ACCESSOR_METADATA),
@@ -71,15 +75,21 @@ public class Function {
     }
 
     public static Function getNewFunctionModel(ServiceClassUtil.ServiceClassContext context) {
-        if (context == ServiceClassUtil.ServiceClassContext.GRAPHQL_DIAGRAM) {
+        if (context == GRAPHQL_DIAGRAM) {
             return new Function(new MetaData("", ""), new ArrayList<>(),
                     ServiceModelGeneratorConstants.KIND_DEFAULT,
                     new Value(ServiceModelGeneratorConstants.FUNCTION_ACCESSOR_METADATA),
                     new Value(ServiceModelGeneratorConstants.FIELD_NAME_METADATA), new ArrayList<>(),
-                    null, new FunctionReturnType(ServiceModelGeneratorConstants.FIELD_TYPE_METADATA),
+                    Map.of(ServiceModelGeneratorConstants.PARAMETER, Parameter.graphQLParamSchema()),
+                    new FunctionReturnType(ServiceModelGeneratorConstants.FIELD_TYPE_METADATA),
                     false, false, false, null);
         }
-        return getNewFunction();
+        Function newFunction = getNewFunctionModel();
+        if (context == TYPE_DIAGRAM || context == SERVICE_DIAGRAM) {
+            newFunction.setSchema(Map.of(ServiceModelGeneratorConstants.PARAMETER, Parameter.functionParamSchema()));
+            return newFunction;
+        }
+        return newFunction;
     }
 
     public MetaData getMetadata() {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Parameter.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Parameter.java
@@ -66,21 +66,6 @@ public class Parameter {
         this.httpParamType = parameter.httpParamType;
     }
 
-    public static Parameter getNewParameter(boolean isGraphQL) {
-        if (isGraphQL) {
-            return new Parameter(null, null,
-                    new Value(ServiceModelGeneratorConstants.ARGUMENT_TYPE_METADATA),
-                    new Value(ServiceModelGeneratorConstants.ARGUMENT_NAME_METADATA),
-                    new Value(ServiceModelGeneratorConstants.ARGUMENT_DEFAULT_VALUE_METADATA),
-                    false, false, false, false, null);
-        }
-        return new Parameter(null, null,
-                new Value(ServiceModelGeneratorConstants.PARAMETER_TYPE_METADATA),
-                new Value(ServiceModelGeneratorConstants.PARAMETER_NAME_METADATA),
-                new Value(ServiceModelGeneratorConstants.PARAMETER_DEFAULT_VALUE_METADATA),
-                false, false, false, false, null);
-    }
-
     public static Parameter getNewField() {
         return new Parameter(null, null,
                 new Value(ServiceModelGeneratorConstants.FIELD_TYPE_METADATA),
@@ -172,14 +157,15 @@ public class Parameter {
         this.httpParamType = httpParamType;
     }
 
-    public static Parameter parameterSchema(boolean isGraphQL) {
-        if (isGraphQL) {
-            return new Parameter(null, null,
-                    new Value(ServiceModelGeneratorConstants.ARGUMENT_TYPE_METADATA),
-                    new Value(ServiceModelGeneratorConstants.ARGUMENT_NAME_METADATA),
-                    new Value(ServiceModelGeneratorConstants.ARGUMENT_DEFAULT_VALUE_METADATA),
-                    false, false, false, false, null);
-        }
+    public static Parameter graphQLParamSchema() {
+        return new Parameter(null, null,
+                new Value(ServiceModelGeneratorConstants.ARGUMENT_TYPE_METADATA),
+                new Value(ServiceModelGeneratorConstants.ARGUMENT_NAME_METADATA),
+                new Value(ServiceModelGeneratorConstants.ARGUMENT_DEFAULT_VALUE_METADATA),
+                false, false, false, false, null);
+    }
+
+    public static Parameter functionParamSchema() {
         return new Parameter(null, null,
                 new Value(ServiceModelGeneratorConstants.PARAMETER_TYPE_METADATA,
                         ServiceModelGeneratorConstants.VALUE_TYPE_TYPE, true),
@@ -187,6 +173,13 @@ public class Parameter {
                         ServiceModelGeneratorConstants.VALUE_TYPE_IDENTIFIER, true),
                 new Value(ServiceModelGeneratorConstants.PARAMETER_DEFAULT_VALUE_METADATA),
                 false, false, false, false, null);
+    }
+
+    public static Parameter getNewParameter(boolean isGraphQL) {
+        if (isGraphQL) {
+            return graphQLParamSchema();
+        }
+        return functionParamSchema();
     }
 
     public static class Builder {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/PropertyTypeMemberInfo.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/PropertyTypeMemberInfo.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+
+package io.ballerina.servicemodelgenerator.extension.model;
+
+/**
+ * Represents the metadata of a diagram component.
+ *
+ * @since 2.0.0
+ */
+public class PropertyTypeMemberInfo {
+
+    private final String type;
+    private final String packageInfo;
+    private final String kind;
+    private boolean selected;
+
+    public PropertyTypeMemberInfo(String type, String packageInfo, String kind, boolean selected) {
+        this.type = type;
+        this.packageInfo = packageInfo;
+        this.kind = kind;
+        this.selected = selected;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public String packageInfo() {
+        return packageInfo;
+    }
+
+    public String kind() {
+        return kind;
+    }
+
+    public boolean selected() {
+        return selected;
+    }
+
+    public void selected(boolean selected) {
+        this.selected = selected;
+    }
+
+    public static class Builder {
+
+        private String type;
+        private String packageInfo;
+        private String kind;
+        private boolean selected = false;
+
+        public Builder() {
+        }
+
+        public Builder type(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder packageInfo(String packageInfo) {
+            this.packageInfo = packageInfo;
+            return this;
+        }
+
+        public Builder kind(String kind) {
+            this.kind = kind;
+            return this;
+        }
+
+        public Builder selected(boolean selected) {
+            this.selected = selected;
+            return this;
+        }
+
+        public PropertyTypeMemberInfo build() {
+            return new PropertyTypeMemberInfo(type, packageInfo, kind, selected);
+        }
+    }
+}

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Value.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Value.java
@@ -41,7 +41,7 @@ public class Value {
     private Codedata codedata;
     private List<Value> choices;
     private boolean addNewButton = false;
-    public List<PropertyTypeMemberInfo> typeMembers;
+    private List<PropertyTypeMemberInfo> typeMembers;
 
     public Value(MetaData metadata, String valueType, boolean editable) {
         this(metadata, false, editable, null, valueType,
@@ -249,6 +249,14 @@ public class Value {
 
     public boolean isAddNewButton() {
         return addNewButton;
+    }
+
+    public List<PropertyTypeMemberInfo> getTypeMembers() {
+        return typeMembers;
+    }
+
+    public void setTypeMembers(List<PropertyTypeMemberInfo> typeMembers) {
+        this.typeMembers = typeMembers;
     }
 
     @Override

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Value.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Value.java
@@ -18,6 +18,8 @@
 
 package io.ballerina.servicemodelgenerator.extension.model;
 
+import io.ballerina.modelgenerator.commons.ParameterMemberTypeData;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +41,7 @@ public class Value {
     private Codedata codedata;
     private List<Value> choices;
     private boolean addNewButton = false;
+    public List<PropertyTypeMemberInfo> typeMembers;
 
     public Value(MetaData metadata, String valueType, boolean editable) {
         this(metadata, false, editable, null, valueType,
@@ -84,7 +87,8 @@ public class Value {
                  String valueType,
                  String valueTypeConstraint, boolean isType, String placeholder, boolean optional,
                  boolean advanced, Map<String, Value> properties, List<String> items, Codedata codedata,
-                 boolean addNewButton) {
+                 boolean addNewButton,
+                 List<PropertyTypeMemberInfo> typeMembers) {
         this.metadata = metadata;
         this.enabled = enabled;
         this.editable = editable;
@@ -100,6 +104,7 @@ public class Value {
         this.items = items;
         this.codedata = codedata;
         this.addNewButton = addNewButton;
+        this.typeMembers = typeMembers;
     }
 
     public MetaData getMetadata() {
@@ -290,6 +295,7 @@ public class Value {
         private List<String> items;
         private Codedata codedata;
         private boolean addNewButton = false;
+        private List<PropertyTypeMemberInfo> typeMembers;
 
         public ValueBuilder setMetadata(MetaData metadata) {
             this.metadata = metadata;
@@ -366,9 +372,15 @@ public class Value {
             return this;
         }
 
+        public ValueBuilder setTypeMembers(List<ParameterMemberTypeData> typeMembers) {
+            this.typeMembers = typeMembers.stream().map(memberType -> new PropertyTypeMemberInfo(memberType.type(),
+                    memberType.packageInfo(), memberType.kind(), false)).toList();
+            return this;
+        }
+
         public Value build() {
             return new Value(metadata, enabled, editable, value, values, valueType, valueTypeConstraint, isType,
-                    placeholder, optional, advanced, properties, items, codedata, addNewButton);
+                    placeholder, optional, advanced, properties, items, codedata, addNewButton, typeMembers);
         }
     }
 }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerDeclAnalyzer.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerDeclAnalyzer.java
@@ -110,8 +110,7 @@ public class ListenerDeclAnalyzer {
                 String unescapedParamName = removeLeadingSingleQuote(paramResult.name());
                 Codedata codedata = new Codedata("LISTENER_INIT_PARAM");
                 codedata.setOriginalName(paramResult.name());
-                Value.ValueBuilder valueBuilder = new Value.ValueBuilder();
-                valueBuilder
+                Value.ValueBuilder valueBuilder = new Value.ValueBuilder()
                         .setMetadata(new MetaData(unescapedParamName, paramResult.description()))
                         .setCodedata(codedata)
                         .setValue("")
@@ -122,7 +121,8 @@ public class ListenerDeclAnalyzer {
                         .setType(false)
                         .setEnabled(true)
                         .setOptional(paramResult.optional())
-                        .setAdvanced(paramResult.optional());
+                        .setAdvanced(paramResult.optional())
+                        .setTypeMembers(paramResult.typeMembers());
                 properties.put(unescapedParamName, valueBuilder.build());
             }
             return;
@@ -166,7 +166,8 @@ public class ListenerDeclAnalyzer {
                             .setType(false)
                             .setEnabled(true)
                             .setOptional(paramResult.optional())
-                            .setAdvanced(paramResult.optional());
+                            .setAdvanced(paramResult.optional())
+                            .setTypeMembers(paramResult.typeMembers());
                     properties.put(unescapedParamName, valueBuilder.build());
                 }
 
@@ -194,7 +195,8 @@ public class ListenerDeclAnalyzer {
                         .setType(false)
                         .setEnabled(true)
                         .setOptional(restParamResult.optional())
-                        .setAdvanced(restParamResult.optional());
+                        .setAdvanced(restParamResult.optional())
+                        .setTypeMembers(restParamResult.typeMembers());
 
                 properties.put(unescapedParamName, valueBuilder.build());
             }
@@ -247,7 +249,8 @@ public class ListenerDeclAnalyzer {
                                     .setType(false)
                                     .setEnabled(true)
                                     .setOptional(paramResult.optional())
-                                    .setAdvanced(paramResult.optional());
+                                    .setAdvanced(paramResult.optional())
+                                    .setTypeMembers(paramResult.typeMembers());
 
                             properties.put(unescapedParamName, valueBuilder.build());
                         } else {
@@ -275,7 +278,8 @@ public class ListenerDeclAnalyzer {
                                         .setType(false)
                                         .setEnabled(true)
                                         .setOptional(paramResult.optional())
-                                        .setAdvanced(paramResult.optional());
+                                        .setAdvanced(paramResult.optional())
+                                        .setTypeMembers(paramResult.typeMembers());
 
                                 properties.put(unescapedParamName, valueBuilder.build());
 
@@ -302,7 +306,8 @@ public class ListenerDeclAnalyzer {
                                     .setType(false)
                                     .setEnabled(true)
                                     .setOptional(paramResult.optional())
-                                    .setAdvanced(paramResult.optional());
+                                    .setAdvanced(paramResult.optional())
+                                    .setTypeMembers(paramResult.typeMembers());
 
                             properties.put(unescapedParamName, valueBuilder.build());
                             return;
@@ -332,7 +337,36 @@ public class ListenerDeclAnalyzer {
                         .setType(false)
                         .setEnabled(true)
                         .setOptional(paramResult.optional())
-                        .setAdvanced(paramResult.optional());
+                        .setAdvanced(paramResult.optional())
+                        .setTypeMembers(paramResult.typeMembers());
+                properties.put(unescapedParamName, valueBuilder.build());
+            }
+
+            for (Map.Entry<String, Node> entry : namedArgValueMap.entrySet()) { // handle remaining named args
+                String escapedParamName = CommonUtil.escapeReservedKeyword(entry.getKey());
+                if (!funcParamMap.containsKey(escapedParamName)) {
+                    continue;
+                }
+                ParameterData paramResult = funcParamMap.remove(escapedParamName);
+                String unescapedParamName = removeLeadingSingleQuote(paramResult.name());
+                Node paramValue = entry.getValue();
+                String value = paramValue != null ? paramValue.toSourceCode() : "";
+                Value.ValueBuilder valueBuilder = new Value.ValueBuilder();
+                Codedata codedata = new Codedata("LISTENER_INIT_PARAM");
+                codedata.setOriginalName(paramResult.name());
+                valueBuilder
+                        .setMetadata(new MetaData(unescapedParamName, paramResult.description()))
+                        .setCodedata(codedata)
+                        .setValue(value)
+                        .setValueType("EXPRESSION")
+                        .setPlaceholder(paramResult.defaultValue())
+                        .setValueTypeConstraint(paramResult.type())
+                        .setEditable(true)
+                        .setType(false)
+                        .setEnabled(true)
+                        .setOptional(paramResult.optional())
+                        .setAdvanced(paramResult.optional())
+                        .setTypeMembers(paramResult.typeMembers());
                 properties.put(unescapedParamName, valueBuilder.build());
             }
             addRemainingParamsToPropertyMap(funcParamMap);
@@ -362,7 +396,8 @@ public class ListenerDeclAnalyzer {
                     .setType(false)
                     .setEnabled(true)
                     .setOptional(paramResult.optional())
-                    .setAdvanced(paramResult.optional());
+                    .setAdvanced(paramResult.optional())
+                    .setTypeMembers(paramResult.typeMembers());
             properties.put(unescapedParamName, valueBuilder.build());
         }
     }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerUtil.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerUtil.java
@@ -238,8 +238,7 @@ public class ListenerUtil {
             Codedata codedata = new Codedata("LISTENER_INIT_PARAM");
             codedata.setOriginalName(paramResult.name());
 
-            Value.ValueBuilder valueBuilder = new Value.ValueBuilder();
-            valueBuilder
+            Value.ValueBuilder valueBuilder = new Value.ValueBuilder()
                     .setMetadata(new MetaData(unescapedParamName, paramResult.description()))
                     .setCodedata(codedata)
                     .setValue("")
@@ -250,7 +249,8 @@ public class ListenerUtil {
                     .setType(false)
                     .setEnabled(true)
                     .setOptional(paramResult.optional())
-                    .setAdvanced(paramResult.optional());
+                    .setAdvanced(paramResult.optional())
+                    .setTypeMembers(paramResult.typeMembers());
 
             properties.put(unescapedParamName, valueBuilder.build());
         }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ServiceClassUtil.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ServiceClassUtil.java
@@ -165,8 +165,6 @@ public class ServiceClassUtil {
         functionModel.setEnabled(true);
         functionModel.setEditable(true);
         functionModel.setCodedata(new Codedata(functionDef.lineRange()));
-        functionModel.setSchema(Map.of(ServiceModelGeneratorConstants.PARAMETER,
-                Parameter.parameterSchema(context == ServiceClassContext.GRAPHQL_DIAGRAM)));
         return functionModel;
     }
 
@@ -275,6 +273,8 @@ public class ServiceClassUtil {
 
     public enum ServiceClassContext {
         TYPE_DIAGRAM,
-        GRAPHQL_DIAGRAM
+        GRAPHQL_DIAGRAM,
+        SERVICE_DIAGRAM,
+        HTTP_DIAGRAM
     }
 }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/services/http.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/resources/services/http.json
@@ -141,46 +141,6 @@
   "functions": [
     {
       "metadata": {
-        "label": "Service Init Function",
-        "description": "The service initialization function"
-      },
-      "kind": "DEFAULT",
-      "enabled": true,
-      "optional": false,
-      "editable": true,
-      "name": {
-        "metadata": {
-          "label": "Init Function",
-          "description": "The init function"
-        },
-        "enabled": true,
-        "editable": false,
-        "value": "init",
-        "valueType": "IDENTIFIER",
-        "valueTypeConstraint": "string",
-        "isType": false,
-        "placeholder": "",
-        "optional": false,
-        "advanced": false
-      },
-      "returnType": {
-        "metadata": {
-          "label": "Return type",
-          "description": "Return type of the function"
-        },
-        "enabled": true,
-        "editable": true,
-        "value": "error?",
-        "valueType": "TYPE",
-        "valueTypeConstraint": "error",
-        "isType": true,
-        "placeholder": "error?",
-        "optional": true,
-        "advanced": false
-      }
-    },
-    {
-      "metadata": {
         "label": "Get Greeting",
         "description": "The get greeting reource"
       },

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/GetServiceModelFromSourceTest.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/java/io/ballerina/servicemodelgenerator/extension/GetServiceModelFromSourceTest.java
@@ -61,7 +61,7 @@ public class GetServiceModelFromSourceTest extends AbstractLSTest {
             GetServiceModelFromSourceTest.TestConfig updatedConfig =
                     new GetServiceModelFromSourceTest.TestConfig(testConfig.filePath(), testConfig.description(),
                             testConfig.start(), testConfig.end(), actualServiceModelJson);
-            updateConfig(configJsonPath, updatedConfig);
+//            updateConfig(configJsonPath, updatedConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }
     }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_listener_model/config/graphql_listener_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_listener_model/config/graphql_listener_model.json
@@ -63,7 +63,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "listenTo"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "Listener",
+              "packageInfo": "ballerina:http:2.13.0",
+              "kind": "OBJECT_TYPE",
+              "selected": false
+            },
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "host": {
           "metadata": {
@@ -86,7 +100,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "host"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http1Settings": {
           "metadata": {
@@ -109,7 +131,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http1Settings"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ListenerHttp1Settings",
+              "packageInfo": "ballerina:http:2.13.0",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "secureSocket": {
           "metadata": {
@@ -132,7 +162,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "secureSocket"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "ListenerSecureSocket",
+              "packageInfo": "ballerina:http:2.13.0",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "httpVersion": {
           "metadata": {
@@ -155,7 +199,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "httpVersion"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "HttpVersion",
+              "packageInfo": "ballerina:http:2.13.0",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeout": {
           "metadata": {
@@ -178,7 +230,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "server": {
           "metadata": {
@@ -201,7 +261,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "server"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "requestLimits": {
           "metadata": {
@@ -224,7 +298,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "requestLimits"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "RequestLimitConfigs",
+              "packageInfo": "ballerina:http:2.13.0",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "gracefulStopTimeout": {
           "metadata": {
@@ -247,7 +329,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "gracefulStopTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "socketConfig": {
           "metadata": {
@@ -270,7 +360,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "socketConfig"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ServerSocketConfig",
+              "packageInfo": "ballerina:http:2.13.0",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http2InitialWindowSize": {
           "metadata": {
@@ -293,7 +391,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http2InitialWindowSize"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "minIdleTimeInStaleState": {
           "metadata": {
@@ -316,7 +422,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "minIdleTimeInStaleState"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeBetweenStaleEviction": {
           "metadata": {
@@ -339,7 +453,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeBetweenStaleEviction"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         }
       }
     }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_listener_model/config/http_listener_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_listener_model/config/http_listener_model.json
@@ -63,7 +63,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "port"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "host": {
           "metadata": {
@@ -86,7 +94,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "host"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http1Settings": {
           "metadata": {
@@ -109,7 +125,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http1Settings"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ListenerHttp1Settings",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "secureSocket": {
           "metadata": {
@@ -132,7 +156,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "secureSocket"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "ListenerSecureSocket",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "httpVersion": {
           "metadata": {
@@ -155,7 +193,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "httpVersion"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "HttpVersion",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeout": {
           "metadata": {
@@ -178,7 +224,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "server": {
           "metadata": {
@@ -201,7 +255,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "server"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "requestLimits": {
           "metadata": {
@@ -224,7 +292,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "requestLimits"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "RequestLimitConfigs",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "gracefulStopTimeout": {
           "metadata": {
@@ -247,7 +323,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "gracefulStopTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "socketConfig": {
           "metadata": {
@@ -270,7 +354,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "socketConfig"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ServerSocketConfig",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http2InitialWindowSize": {
           "metadata": {
@@ -293,7 +385,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http2InitialWindowSize"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "minIdleTimeInStaleState": {
           "metadata": {
@@ -316,7 +416,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "minIdleTimeInStaleState"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeBetweenStaleEviction": {
           "metadata": {
@@ -339,7 +447,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeBetweenStaleEviction"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         }
       }
     }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_listener_model/config/kafka_listener_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_listener_model/config/kafka_listener_model.json
@@ -63,7 +63,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "bootstrapServers"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "ARRAY_TYPE",
+              "selected": false
+            },
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "groupId": {
           "metadata": {
@@ -86,7 +100,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "groupId"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "topics": {
           "metadata": {
@@ -109,7 +131,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "topics"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "ARRAY_TYPE",
+              "selected": false
+            },
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "offsetReset": {
           "metadata": {
@@ -132,7 +168,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "offsetReset"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "OffsetResetMethod",
+              "packageInfo": "ballerinax:kafka:4.2.0",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "partitionAssignmentStrategy": {
           "metadata": {
@@ -155,7 +199,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "partitionAssignmentStrategy"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "metricsRecordingLevel": {
           "metadata": {
@@ -178,7 +230,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "metricsRecordingLevel"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "metricsReporterClasses": {
           "metadata": {
@@ -201,7 +261,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "metricsReporterClasses"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "clientId": {
           "metadata": {
@@ -224,7 +292,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "clientId"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "interceptorClasses": {
           "metadata": {
@@ -247,7 +323,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "interceptorClasses"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "isolationLevel": {
           "metadata": {
@@ -270,7 +354,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "isolationLevel"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "IsolationLevel",
+              "packageInfo": "ballerinax:kafka:4.2.0",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "schemaRegistryUrl": {
           "metadata": {
@@ -293,7 +385,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "schemaRegistryUrl"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "additionalProperties": {
           "metadata": {
@@ -316,7 +416,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "additionalProperties"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "map<string>",
+              "packageInfo": "",
+              "kind": "MAP_TYPE",
+              "selected": false
+            }
+          ]
         },
         "sessionTimeout": {
           "metadata": {
@@ -339,7 +447,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "sessionTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "heartBeatInterval": {
           "metadata": {
@@ -362,7 +478,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "heartBeatInterval"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "metadataMaxAge": {
           "metadata": {
@@ -385,7 +509,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "metadataMaxAge"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "autoCommitInterval": {
           "metadata": {
@@ -408,7 +540,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "autoCommitInterval"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "maxPartitionFetchBytes": {
           "metadata": {
@@ -431,7 +571,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "maxPartitionFetchBytes"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "sendBuffer": {
           "metadata": {
@@ -454,7 +602,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "sendBuffer"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "receiveBuffer": {
           "metadata": {
@@ -477,7 +633,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "receiveBuffer"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "fetchMinBytes": {
           "metadata": {
@@ -500,7 +664,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "fetchMinBytes"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "fetchMaxBytes": {
           "metadata": {
@@ -523,7 +695,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "fetchMaxBytes"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "fetchMaxWaitTime": {
           "metadata": {
@@ -546,7 +726,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "fetchMaxWaitTime"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "reconnectBackoffTimeMax": {
           "metadata": {
@@ -569,7 +757,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "reconnectBackoffTimeMax"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "retryBackoff": {
           "metadata": {
@@ -592,7 +788,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "retryBackoff"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "metricsSampleWindow": {
           "metadata": {
@@ -615,7 +819,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "metricsSampleWindow"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "metricsNumSamples": {
           "metadata": {
@@ -638,7 +850,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "metricsNumSamples"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "requestTimeout": {
           "metadata": {
@@ -661,7 +881,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "requestTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "connectionMaxIdleTime": {
           "metadata": {
@@ -684,7 +912,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "connectionMaxIdleTime"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "maxPollRecords": {
           "metadata": {
@@ -707,7 +943,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "maxPollRecords"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "maxPollInterval": {
           "metadata": {
@@ -730,7 +974,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "maxPollInterval"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "reconnectBackoffTime": {
           "metadata": {
@@ -753,7 +1005,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "reconnectBackoffTime"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "pollingTimeout": {
           "metadata": {
@@ -776,7 +1036,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "pollingTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "pollingInterval": {
           "metadata": {
@@ -799,7 +1067,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "pollingInterval"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "concurrentConsumers": {
           "metadata": {
@@ -822,7 +1098,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "concurrentConsumers"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "defaultApiTimeout": {
           "metadata": {
@@ -845,7 +1129,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "defaultApiTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "autoCommit": {
           "metadata": {
@@ -868,7 +1160,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "autoCommit"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "boolean",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "checkCRCS": {
           "metadata": {
@@ -891,7 +1191,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "checkCRCS"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "boolean",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "excludeInternalTopics": {
           "metadata": {
@@ -914,7 +1222,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "excludeInternalTopics"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "boolean",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "decoupleProcessing": {
           "metadata": {
@@ -937,7 +1253,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "decoupleProcessing"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "boolean",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "validation": {
           "metadata": {
@@ -960,7 +1284,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "validation"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "boolean",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "autoSeekOnValidationFailure": {
           "metadata": {
@@ -983,7 +1315,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "autoSeekOnValidationFailure"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "boolean",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "secureSocket": {
           "metadata": {
@@ -1006,7 +1346,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "secureSocket"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "SecureSocket",
+              "packageInfo": "ballerinax:kafka:4.2.0",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "auth": {
           "metadata": {
@@ -1029,7 +1377,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "auth"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "AuthenticationConfiguration",
+              "packageInfo": "ballerinax:kafka:4.2.0",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "securityProtocol": {
           "metadata": {
@@ -1052,7 +1408,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "securityProtocol"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "SecurityProtocol",
+              "packageInfo": "ballerinax:kafka:4.2.0",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         }
       }
     }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/graphql_service_with_single_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/graphql_service_with_single_listener.json
@@ -157,11 +157,12 @@
           "parameter": {
             "type": {
               "metadata": {
-                "label": "Argument Type",
-                "description": "The type of the argument"
+                "label": "Parameter Type",
+                "description": "The type of the parameter"
               },
               "enabled": false,
               "editable": true,
+              "valueType": "TYPE",
               "isType": false,
               "optional": false,
               "advanced": false,
@@ -169,11 +170,12 @@
             },
             "name": {
               "metadata": {
-                "label": "Argument Name",
-                "description": "The name of the argument"
+                "label": "Parameter Name",
+                "description": "The name of the parameter"
               },
               "enabled": false,
               "editable": true,
+              "valueType": "IDENTIFIER",
               "isType": false,
               "optional": false,
               "advanced": false,
@@ -182,7 +184,7 @@
             "defaultValue": {
               "metadata": {
                 "label": "Default Value",
-                "description": "The default value of the argument"
+                "description": "The default value of the parameter"
               },
               "enabled": false,
               "editable": true,
@@ -365,8 +367,8 @@
         },
         "returnType": {
           "metadata": {
-            "label": "Return Type",
-            "description": "The return type of the function"
+            "label": "Field Type",
+            "description": "The type of the field"
           },
           "enabled": true,
           "editable": true,
@@ -580,8 +582,8 @@
         },
         "returnType": {
           "metadata": {
-            "label": "Return Type",
-            "description": "The return type of the function"
+            "label": "Field Type",
+            "description": "The type of the field"
           },
           "enabled": true,
           "editable": true,
@@ -694,8 +696,8 @@
         },
         "returnType": {
           "metadata": {
-            "label": "Return Type",
-            "description": "The return type of the function"
+            "label": "Field Type",
+            "description": "The type of the field"
           },
           "enabled": true,
           "editable": true,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_anonymous_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_anonymous_listener.json
@@ -40,7 +40,7 @@
         "optional": false,
         "advanced": false,
         "items": [
-          "(+) Create and use the default HTTP listener",
+          "(+) Create and use the default HTTP listener (port: 8080)",
           "new http:Listener(port = 8080)"
         ],
         "codedata": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_global_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_global_listener.json
@@ -47,7 +47,7 @@
         "items": [
           "httpListener",
           "githubListener",
-          "(+) Create and use the default HTTP listener",
+          "(+) Create and use the default HTTP listener (port: 8080)",
           "default:globalListener",
           "new http:Listener(port = 8080)"
         ],

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_multiple_listeners.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_multiple_listeners.json
@@ -46,7 +46,7 @@
         "items": [
           "httpListener",
           "githubListener",
-          "(+) Create and use the default HTTP listener",
+          "(+) Create and use the default HTTP listener (port: 8080)",
           "new http:Listener(port = 8080)"
         ],
         "codedata": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_single_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_single_listener.json
@@ -42,7 +42,7 @@
         "items": [
           "httpListener",
           "githubListener",
-          "(+) Create and use the default HTTP listener"
+          "(+) Create and use the default HTTP listener (port: 8080)"
         ],
         "codedata": {
           "inListenerInit": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_1.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_1.json
@@ -79,7 +79,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "port"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "host": {
           "metadata": {
@@ -102,7 +110,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "host"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http1Settings": {
           "metadata": {
@@ -125,7 +141,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http1Settings"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ListenerHttp1Settings",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "secureSocket": {
           "metadata": {
@@ -148,7 +172,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "secureSocket"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "ListenerSecureSocket",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "httpVersion": {
           "metadata": {
@@ -171,7 +209,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "httpVersion"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "HttpVersion",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeout": {
           "metadata": {
@@ -194,7 +240,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "server": {
           "metadata": {
@@ -217,7 +271,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "server"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "requestLimits": {
           "metadata": {
@@ -240,7 +308,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "requestLimits"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "RequestLimitConfigs",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "gracefulStopTimeout": {
           "metadata": {
@@ -263,7 +339,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "gracefulStopTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "socketConfig": {
           "metadata": {
@@ -286,7 +370,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "socketConfig"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ServerSocketConfig",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http2InitialWindowSize": {
           "metadata": {
@@ -309,7 +401,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http2InitialWindowSize"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "minIdleTimeInStaleState": {
           "metadata": {
@@ -332,7 +432,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "minIdleTimeInStaleState"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeBetweenStaleEviction": {
           "metadata": {
@@ -355,7 +463,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeBetweenStaleEviction"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         }
       },
       "codedata": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_2.json
@@ -79,7 +79,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "port"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "host": {
           "metadata": {
@@ -102,7 +110,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "host"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http1Settings": {
           "metadata": {
@@ -125,7 +141,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http1Settings"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ListenerHttp1Settings",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "secureSocket": {
           "metadata": {
@@ -148,7 +172,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "secureSocket"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "ListenerSecureSocket",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "httpVersion": {
           "metadata": {
@@ -171,7 +209,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "httpVersion"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "HttpVersion",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeout": {
           "metadata": {
@@ -194,7 +240,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "server": {
           "metadata": {
@@ -217,7 +271,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "server"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "requestLimits": {
           "metadata": {
@@ -240,7 +308,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "requestLimits"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "RequestLimitConfigs",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "gracefulStopTimeout": {
           "metadata": {
@@ -263,7 +339,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "gracefulStopTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "socketConfig": {
           "metadata": {
@@ -286,7 +370,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "socketConfig"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ServerSocketConfig",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http2InitialWindowSize": {
           "metadata": {
@@ -309,7 +401,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http2InitialWindowSize"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "minIdleTimeInStaleState": {
           "metadata": {
@@ -332,7 +432,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "minIdleTimeInStaleState"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeBetweenStaleEviction": {
           "metadata": {
@@ -355,7 +463,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeBetweenStaleEviction"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         }
       },
       "codedata": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_3.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_3.json
@@ -79,7 +79,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "port"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "config": {
           "metadata": {
@@ -102,7 +110,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "config"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ListenerConfiguration",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         }
       },
       "codedata": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_4.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/listener_from_source/config/listener_from_source_4.json
@@ -79,7 +79,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "port"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "socketConfig": {
           "metadata": {
@@ -102,7 +110,52 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "socketConfig"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ServerSocketConfig",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
+        },
+        "server": {
+          "metadata": {
+            "label": "server",
+            "description": ""
+          },
+          "enabled": true,
+          "editable": true,
+          "value": "\"0.0.0.0\"",
+          "valueType": "EXPRESSION",
+          "valueTypeConstraint": "string|()",
+          "isType": false,
+          "placeholder": "()",
+          "optional": true,
+          "advanced": true,
+          "codedata": {
+            "inListenerInit": false,
+            "isBasePath": false,
+            "inDisplayAnnotation": false,
+            "type": "LISTENER_INIT_PARAM",
+            "originalName": "server"
+          },
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "host": {
           "metadata": {
@@ -125,7 +178,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "host"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "string",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http1Settings": {
           "metadata": {
@@ -148,7 +209,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http1Settings"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "ListenerHttp1Settings",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "secureSocket": {
           "metadata": {
@@ -171,7 +240,21 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "secureSocket"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "()",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            },
+            {
+              "type": "ListenerSecureSocket",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "httpVersion": {
           "metadata": {
@@ -194,7 +277,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "httpVersion"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "HttpVersion",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeout": {
           "metadata": {
@@ -217,30 +308,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeout"
           },
-          "addNewButton": false
-        },
-        "server": {
-          "metadata": {
-            "label": "server",
-            "description": ""
-          },
-          "enabled": true,
-          "editable": true,
-          "value": "",
-          "valueType": "EXPRESSION",
-          "valueTypeConstraint": "string|()",
-          "isType": false,
-          "placeholder": "()",
-          "optional": true,
-          "advanced": true,
-          "codedata": {
-            "inListenerInit": false,
-            "isBasePath": false,
-            "inDisplayAnnotation": false,
-            "type": "LISTENER_INIT_PARAM",
-            "originalName": "server"
-          },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "requestLimits": {
           "metadata": {
@@ -263,7 +339,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "requestLimits"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "RequestLimitConfigs",
+              "packageInfo": "ballerina:http:2.12.2",
+              "kind": "RECORD_TYPE",
+              "selected": false
+            }
+          ]
         },
         "gracefulStopTimeout": {
           "metadata": {
@@ -286,7 +370,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "gracefulStopTimeout"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "http2InitialWindowSize": {
           "metadata": {
@@ -309,7 +401,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "http2InitialWindowSize"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "int",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "minIdleTimeInStaleState": {
           "metadata": {
@@ -332,7 +432,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "minIdleTimeInStaleState"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         },
         "timeBetweenStaleEviction": {
           "metadata": {
@@ -355,7 +463,15 @@
             "type": "LISTENER_INIT_PARAM",
             "originalName": "timeBetweenStaleEviction"
           },
-          "addNewButton": false
+          "addNewButton": false,
+          "typeMembers": [
+            {
+              "type": "decimal",
+              "packageInfo": "",
+              "kind": "BASIC_TYPE",
+              "selected": false
+            }
+          ]
         }
       },
       "codedata": {


### PR DESCRIPTION
## Purpose
$subject

This PR fixes following things.

1. Remove init function gen for http service creation

2. Add a return statement to greetings function in http service creation


https://github.com/user-attachments/assets/38a334d7-39a7-4c0f-8d09-7590445784c6


3. Show port information of the default listener
<img width="597" alt="Screenshot 2025-03-09 at 18 07 56" src="https://github.com/user-attachments/assets/b7f7da73-e1f8-4b84-991a-b9cc888908c6" />


4. Fix few graphql forms metadata
<img width="400" alt="Screenshot 2025-03-09 at 18 07 21" src="https://github.com/user-attachments/assets/5b647a71-89f2-4cf4-9fdc-1955ffd0e333" />

5. Support record value editing for Listener forms

