### PR TITLE
Make the type generator concurrency-safe

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -91,7 +91,7 @@ public class TypesGenerator {
             "Primitive Types",
             List.of(TYPE_STRING, TYPE_INT, TYPE_FLOAT, TYPE_DECIMAL, TYPE_BOOLEAN, TYPE_NIL, TYPE_BYTE),
             "Data Types", List.of(TYPE_JSON, TYPE_XML, TYPE_ANYDATA),
-            "Structural Types", List.of(TYPE_BYTE_ARRAY, TYPE_MAP_JSON, TYPE_MAP_STRING, TYPE_JSON_ARRAY),
+            "Structural Types", List.of(TYPE_BYTE_ARRAY, TYPE_MAP_JSON, TYPE_MAP_STRING, TYPE_JSON_ARRAY, TYPE_RECORD),
             "Error Types", List.of(TYPE_ERROR),
             "Behaviour Types", List.of(TYPE_FUNCTION, TYPE_FUTURE, TYPE_TYPEDESC, TYPE_HANDLE, TYPE_STREAM),
             "Other Types", List.of(TYPE_ANY, TYPE_READONLY));
@@ -177,7 +177,7 @@ public class TypesGenerator {
         typeSymbolMap.put(TYPE_JSON_ARRAY, types.builder().ARRAY_TYPE.withType(types.JSON).build());
         typeSymbolMap.put(TYPE_BYTE_ARRAY, types.builder().ARRAY_TYPE.withType(types.BYTE).build());
 
-        // Build the completion items for the builtin types.eq
+        // Build the completion items for the builtin types
         categoryMap.forEach((category, typeNames) -> {
             typeNames.forEach(typeName -> {
                 TypeSymbol symbol = typeSymbolMap.get(typeName);

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -48,6 +48,7 @@ public class TypesGenerator {
     private final Map<String, TypeSymbol> typeSymbolMap;
     private final Map<TypeSymbol, CompletionItem> completionItemMap;
     private final Map<TypeSymbol, List<CompletionItem>> subtypeItemsMap;
+    private volatile boolean initialized = false;
 
     private static final String USER_DEFINED_TYPE = "User-Defined";
     private static final List<SymbolKind> TYPE_SYMBOL_KINDS = List.of(SymbolKind.TYPE_DEFINITION, SymbolKind.CLASS,
@@ -147,52 +148,60 @@ public class TypesGenerator {
     }
 
     private void initializeBuiltinTypes(SemanticModel semanticModel) {
-        if (!typeSymbolMap.isEmpty()) {
+        if (initialized) {
             return;
         }
 
-        // Obtain the type symbols for the builtin types
-        Types types = semanticModel.types();
-        typeSymbolMap.put(TYPE_STRING, types.STRING);
-        typeSymbolMap.put(TYPE_BOOLEAN, types.BOOLEAN);
-        typeSymbolMap.put(TYPE_INT, types.INT);
-        typeSymbolMap.put(TYPE_NIL, types.NIL);
-        typeSymbolMap.put(TYPE_FLOAT, types.FLOAT);
-        typeSymbolMap.put(TYPE_DECIMAL, types.DECIMAL);
-        typeSymbolMap.put(TYPE_XML, types.XML);
-        typeSymbolMap.put(TYPE_BYTE, types.BYTE);
-        typeSymbolMap.put(TYPE_ERROR, types.ERROR);
-        typeSymbolMap.put(TYPE_JSON, types.JSON);
-        typeSymbolMap.put(TYPE_ANY, types.ANY);
-        typeSymbolMap.put(TYPE_ANYDATA, types.ANYDATA);
-        typeSymbolMap.put(TYPE_FUNCTION, types.FUNCTION);
-        typeSymbolMap.put(TYPE_FUTURE, types.FUTURE);
-        typeSymbolMap.put(TYPE_TYPEDESC, types.TYPEDESC);
-        typeSymbolMap.put(TYPE_HANDLE, types.HANDLE);
-        typeSymbolMap.put(TYPE_STREAM, types.STREAM);
-        typeSymbolMap.put(TYPE_READONLY, types.READONLY);
-        typeSymbolMap.put(TYPE_RECORD, types.builder().RECORD_TYPE.withRestField(types.ANYDATA).build());
-        typeSymbolMap.put(TYPE_MAP_JSON, types.builder().MAP_TYPE.withTypeParam(types.JSON).build());
-        typeSymbolMap.put(TYPE_MAP_STRING, types.builder().MAP_TYPE.withTypeParam(types.STRING).build());
-        typeSymbolMap.put(TYPE_JSON_ARRAY, types.builder().ARRAY_TYPE.withType(types.JSON).build());
-        typeSymbolMap.put(TYPE_BYTE_ARRAY, types.builder().ARRAY_TYPE.withType(types.BYTE).build());
+        synchronized (this) {
+            if (initialized) {
+                return;
+            }
 
-        // Build the completion items for the builtin types
-        categoryMap.forEach((category, typeNames) -> {
-            typeNames.forEach(typeName -> {
-                TypeSymbol symbol = typeSymbolMap.get(typeName);
-                completionItemMap.put(symbol, TypeCompletionItemBuilder.build(symbol, typeName, category));
+            // Obtain the type symbols for the builtin types
+            Types types = semanticModel.types();
+            typeSymbolMap.put(TYPE_STRING, types.STRING);
+            typeSymbolMap.put(TYPE_BOOLEAN, types.BOOLEAN);
+            typeSymbolMap.put(TYPE_INT, types.INT);
+            typeSymbolMap.put(TYPE_NIL, types.NIL);
+            typeSymbolMap.put(TYPE_FLOAT, types.FLOAT);
+            typeSymbolMap.put(TYPE_DECIMAL, types.DECIMAL);
+            typeSymbolMap.put(TYPE_XML, types.XML);
+            typeSymbolMap.put(TYPE_BYTE, types.BYTE);
+            typeSymbolMap.put(TYPE_ERROR, types.ERROR);
+            typeSymbolMap.put(TYPE_JSON, types.JSON);
+            typeSymbolMap.put(TYPE_ANY, types.ANY);
+            typeSymbolMap.put(TYPE_ANYDATA, types.ANYDATA);
+            typeSymbolMap.put(TYPE_FUNCTION, types.FUNCTION);
+            typeSymbolMap.put(TYPE_FUTURE, types.FUTURE);
+            typeSymbolMap.put(TYPE_TYPEDESC, types.TYPEDESC);
+            typeSymbolMap.put(TYPE_HANDLE, types.HANDLE);
+            typeSymbolMap.put(TYPE_STREAM, types.STREAM);
+            typeSymbolMap.put(TYPE_READONLY, types.READONLY);
+            typeSymbolMap.put(TYPE_RECORD, types.builder().RECORD_TYPE.withRestField(types.ANYDATA).build());
+            typeSymbolMap.put(TYPE_MAP_JSON, types.builder().MAP_TYPE.withTypeParam(types.JSON).build());
+            typeSymbolMap.put(TYPE_MAP_STRING, types.builder().MAP_TYPE.withTypeParam(types.STRING).build());
+            typeSymbolMap.put(TYPE_JSON_ARRAY, types.builder().ARRAY_TYPE.withType(types.JSON).build());
+            typeSymbolMap.put(TYPE_BYTE_ARRAY, types.builder().ARRAY_TYPE.withType(types.BYTE).build());
+
+            // Build the completion items for the builtin types
+            categoryMap.forEach((category, typeNames) -> {
+                typeNames.forEach(typeName -> {
+                    TypeSymbol symbol = typeSymbolMap.get(typeName);
+                    completionItemMap.put(symbol, TypeCompletionItemBuilder.build(symbol, typeName, category));
+                });
             });
-        });
 
-        // Build the subtype items for the builtin types
-        typeSymbolMap.forEach((name, symbol) -> {
-            List<CompletionItem> completionsList = typeSymbolMap.values().parallelStream()
-                    .filter(typeSymbol -> typeSymbol.subtypeOf(symbol))
-                    .map(completionItemMap::get)
-                    .toList();
-            subtypeItemsMap.put(symbol, completionsList);
-        });
+            // Build the subtype items for the builtin types
+            typeSymbolMap.forEach((name, symbol) -> {
+                List<CompletionItem> completionsList = typeSymbolMap.values().parallelStream()
+                        .filter(typeSymbol -> typeSymbol.subtypeOf(symbol))
+                        .map(completionItemMap::get)
+                        .toList();
+                subtypeItemsMap.put(symbol, completionsList);
+            });
+
+            initialized = true;
+        }
     }
 
     public static TypesGenerator getInstance() {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -58,7 +58,7 @@ public class TypesGenerator {
     public static final String TYPE_DECIMAL = TypeKind.DECIMAL.typeName();
     public static final String TYPE_FLOAT = TypeKind.FLOAT.typeName();
     public static final String TYPE_INT = TypeKind.INT.typeName();
-    public static final String TYPE_NIL = TypeKind.NIL.typeName();
+    public static final String TYPE_NIL = "()";
 
     // Basic sequence types
     public static final String TYPE_STRING = TypeKind.STRING.typeName();

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
@@ -168,6 +168,15 @@
       "insertText": "json[]"
     },
     {
+      "label": "record",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "record"
+    },
+    {
       "label": "function",
       "labelDetails": {
         "detail": "Behaviour Types",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config1.json
@@ -69,24 +69,6 @@
       "insertText": "Admission"
     },
     {
-      "label": "any",
-      "labelDetails": {
-        "detail": "Other Types",
-        "description": "Any"
-      },
-      "kind": "TypeParameter",
-      "insertText": "any"
-    },
-    {
-      "label": "readonly",
-      "labelDetails": {
-        "detail": "Other Types",
-        "description": "Readonly"
-      },
-      "kind": "TypeParameter",
-      "insertText": "readonly"
-    },
-    {
       "label": "string",
       "labelDetails": {
         "detail": "Primitive Types",
@@ -132,13 +114,13 @@
       "insertText": "boolean"
     },
     {
-      "label": "null",
+      "label": "()",
       "labelDetails": {
         "detail": "Primitive Types",
         "description": "Nil"
       },
       "kind": "TypeParameter",
-      "insertText": "null"
+      "insertText": "()"
     },
     {
       "label": "byte",
@@ -265,6 +247,24 @@
       },
       "kind": "TypeParameter",
       "insertText": "anydata"
+    },
+    {
+      "label": "any",
+      "labelDetails": {
+        "detail": "Other Types",
+        "description": "Any"
+      },
+      "kind": "TypeParameter",
+      "insertText": "any"
+    },
+    {
+      "label": "readonly",
+      "labelDetails": {
+        "detail": "Other Types",
+        "description": "Readonly"
+      },
+      "kind": "TypeParameter",
+      "insertText": "readonly"
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config2.json
@@ -69,7 +69,15 @@
       "kind": "Struct",
       "insertText": "Admission"
     },
-    null,
+    {
+      "label": "record",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "record"
+    },
     {
       "label": "map<json>",
       "labelDetails": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
@@ -279,6 +279,15 @@
       "insertText": "json[]"
     },
     {
+      "label": "record",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "record"
+    },
+    {
       "label": "function",
       "labelDetails": {
         "detail": "Behaviour Types",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config4.json
@@ -180,24 +180,6 @@
       "insertText": "UserProfile"
     },
     {
-      "label": "any",
-      "labelDetails": {
-        "detail": "Other Types",
-        "description": "Any"
-      },
-      "kind": "TypeParameter",
-      "insertText": "any"
-    },
-    {
-      "label": "readonly",
-      "labelDetails": {
-        "detail": "Other Types",
-        "description": "Readonly"
-      },
-      "kind": "TypeParameter",
-      "insertText": "readonly"
-    },
-    {
       "label": "string",
       "labelDetails": {
         "detail": "Primitive Types",
@@ -243,13 +225,13 @@
       "insertText": "boolean"
     },
     {
-      "label": "null",
+      "label": "()",
       "labelDetails": {
         "detail": "Primitive Types",
         "description": "Nil"
       },
       "kind": "TypeParameter",
-      "insertText": "null"
+      "insertText": "()"
     },
     {
       "label": "byte",
@@ -376,6 +358,24 @@
       },
       "kind": "TypeParameter",
       "insertText": "anydata"
+    },
+    {
+      "label": "any",
+      "labelDetails": {
+        "detail": "Other Types",
+        "description": "Any"
+      },
+      "kind": "TypeParameter",
+      "insertText": "any"
+    },
+    {
+      "label": "readonly",
+      "labelDetails": {
+        "detail": "Other Types",
+        "description": "Readonly"
+      },
+      "kind": "TypeParameter",
+      "insertText": "readonly"
     }
   ]
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
@@ -159,7 +159,15 @@
       "kind": "TypeParameter",
       "insertText": "anydata"
     },
-    null,
+    {
+      "label": "record",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "record"
+    },
     {
       "label": "map<json>",
       "labelDetails": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
@@ -97,13 +97,13 @@
       "insertText": "int"
     },
     {
-      "label": "null",
+      "label": "()",
       "labelDetails": {
         "detail": "Primitive Types",
         "description": "Nil"
       },
       "kind": "TypeParameter",
-      "insertText": "null"
+      "insertText": "()"
     },
     {
       "label": "float",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config6.json
@@ -70,13 +70,13 @@
       "insertText": "int"
     },
     {
-      "label": "null",
+      "label": "()",
       "labelDetails": {
         "detail": "Primitive Types",
         "description": "Nil"
       },
       "kind": "TypeParameter",
-      "insertText": "null"
+      "insertText": "()"
     },
     {
       "label": "float",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
@@ -213,7 +213,15 @@
       "kind": "TypeParameter",
       "insertText": "stream"
     },
-    null,
+    {
+      "label": "record",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "record"
+    },
     {
       "label": "map<json>",
       "labelDetails": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
@@ -97,13 +97,13 @@
       "insertText": "int"
     },
     {
-      "label": "null",
+      "label": "()",
       "labelDetails": {
         "detail": "Primitive Types",
         "description": "Nil"
       },
       "kind": "TypeParameter",
-      "insertText": "null"
+      "insertText": "()"
     },
     {
       "label": "float",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config9.json
@@ -1,6 +1,6 @@
 {
   "description": "",
-  "source": "data_mapper",
+  "source": "data_mapper/main.bal",
   "typeConstraint": "record",
   "completions": [
     {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/non_existence.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/non_existence.json
@@ -1,200 +1,200 @@
 {
-    "description": "",
-    "source": "data_mapper",
-    "typeConstraint": "anydata",
-    "completions": [
-      {
-        "label": "Input",
-        "labelDetails": {
-          "detail": "User-Defined",
-          "description": "Record"
-        },
-        "kind": "Struct",
-        "insertText": "Input"
+  "description": "",
+  "source": "data_mapper",
+  "typeConstraint": "anydata",
+  "completions": [
+    {
+      "label": "Input",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
       },
-      {
-        "label": "Output",
-        "labelDetails": {
-          "detail": "User-Defined",
-          "description": "Record"
-        },
-        "kind": "Struct",
-        "insertText": "Output"
+      "kind": "Struct",
+      "insertText": "Input"
+    },
+    {
+      "label": "Output",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
       },
-      {
-        "label": "Location",
-        "labelDetails": {
-          "detail": "User-Defined",
-          "description": "Record"
-        },
-        "kind": "Struct",
-        "documentation": {
-          "left": "Represents a geographical location.\n"
-        },
-        "insertText": "Location"
+      "kind": "Struct",
+      "insertText": "Output"
+    },
+    {
+      "label": "Location",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
       },
-      {
-        "label": "Address",
-        "labelDetails": {
-          "detail": "User-Defined",
-          "description": "Record"
-        },
-        "kind": "Struct",
-        "insertText": "Address"
+      "kind": "Struct",
+      "documentation": {
+        "left": "Represents a geographical location.\n"
       },
-      {
-        "label": "Employee",
-        "labelDetails": {
-          "detail": "User-Defined",
-          "description": "Record"
-        },
-        "kind": "Struct",
-        "insertText": "Employee"
+      "insertText": "Location"
+    },
+    {
+      "label": "Address",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
       },
-      {
-        "label": "Person",
-        "labelDetails": {
-          "detail": "User-Defined",
-          "description": "Record"
-        },
-        "kind": "Struct",
-        "insertText": "Person"
+      "kind": "Struct",
+      "insertText": "Address"
+    },
+    {
+      "label": "Employee",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
       },
-      {
-        "label": "Admission",
-        "labelDetails": {
-          "detail": "User-Defined",
-          "description": "Record"
-        },
-        "kind": "Struct",
-        "insertText": "Admission"
+      "kind": "Struct",
+      "insertText": "Employee"
+    },
+    {
+      "label": "Person",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
       },
-      {
-        "label": "string",
-        "labelDetails": {
-          "detail": "Primitive Types",
-          "description": "String"
-        },
-        "kind": "TypeParameter",
-        "insertText": "string"
+      "kind": "Struct",
+      "insertText": "Person"
+    },
+    {
+      "label": "Admission",
+      "labelDetails": {
+        "detail": "User-Defined",
+        "description": "Record"
       },
-      {
-        "label": "boolean",
-        "labelDetails": {
-          "detail": "Primitive Types",
-          "description": "Boolean"
-        },
-        "kind": "TypeParameter",
-        "insertText": "boolean"
+      "kind": "Struct",
+      "insertText": "Admission"
+    },
+    {
+      "label": "string",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "String"
       },
-      {
-        "label": "int",
-        "labelDetails": {
-          "detail": "Primitive Types",
-          "description": "Int"
-        },
-        "kind": "TypeParameter",
-        "insertText": "int"
+      "kind": "TypeParameter",
+      "insertText": "string"
+    },
+    {
+      "label": "boolean",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Boolean"
       },
-      {
-        "label": "null",
-        "labelDetails": {
-          "detail": "Primitive Types",
-          "description": "Nil"
-        },
-        "kind": "TypeParameter",
-        "insertText": "null"
+      "kind": "TypeParameter",
+      "insertText": "boolean"
+    },
+    {
+      "label": "int",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Int"
       },
-      {
-        "label": "float",
-        "labelDetails": {
-          "detail": "Primitive Types",
-          "description": "Float"
-        },
-        "kind": "TypeParameter",
-        "insertText": "float"
+      "kind": "TypeParameter",
+      "insertText": "int"
+    },
+    {
+      "label": "()",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Nil"
       },
-      {
-        "label": "decimal",
-        "labelDetails": {
-          "detail": "Primitive Types",
-          "description": "Decimal"
-        },
-        "kind": "TypeParameter",
-        "insertText": "decimal"
+      "kind": "TypeParameter",
+      "insertText": "()"
+    },
+    {
+      "label": "float",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Float"
       },
-      {
-        "label": "xml",
-        "labelDetails": {
-          "detail": "Data Types",
-          "description": "Xml"
-        },
-        "kind": "TypeParameter",
-        "insertText": "xml"
+      "kind": "TypeParameter",
+      "insertText": "float"
+    },
+    {
+      "label": "decimal",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Decimal"
       },
-      {
-        "label": "byte",
-        "labelDetails": {
-          "detail": "Primitive Types",
-          "description": "Byte"
-        },
-        "kind": "TypeParameter",
-        "insertText": "byte"
+      "kind": "TypeParameter",
+      "insertText": "decimal"
+    },
+    {
+      "label": "xml",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Xml"
       },
-      {
-        "label": "json",
-        "labelDetails": {
-          "detail": "Data Types",
-          "description": "Json"
-        },
-        "kind": "TypeParameter",
-        "insertText": "json"
+      "kind": "TypeParameter",
+      "insertText": "xml"
+    },
+    {
+      "label": "byte",
+      "labelDetails": {
+        "detail": "Primitive Types",
+        "description": "Byte"
       },
-      {
-        "label": "anydata",
-        "labelDetails": {
-          "detail": "Data Types",
-          "description": "Anydata"
-        },
-        "kind": "TypeParameter",
-        "insertText": "anydata"
+      "kind": "TypeParameter",
+      "insertText": "byte"
+    },
+    {
+      "label": "json",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Json"
       },
-      null,
-      {
-        "label": "map<json>",
-        "labelDetails": {
-          "detail": "Structural Types",
-          "description": "Map"
-        },
-        "kind": "TypeParameter",
-        "insertText": "map<json>"
+      "kind": "TypeParameter",
+      "insertText": "json"
+    },
+    {
+      "label": "anydata",
+      "labelDetails": {
+        "detail": "Data Types",
+        "description": "Anydata"
       },
-      {
-        "label": "map<string>",
-        "labelDetails": {
-          "detail": "Structural Types",
-          "description": "Map"
-        },
-        "kind": "TypeParameter",
-        "insertText": "map<string>"
+      "kind": "TypeParameter",
+      "insertText": "anydata"
+    },
+    null,
+    {
+      "label": "map<json>",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Map"
       },
-      {
-        "label": "json[]",
-        "labelDetails": {
-          "detail": "Structural Types",
-          "description": "Array"
-        },
-        "kind": "TypeParameter",
-        "insertText": "json[]"
+      "kind": "TypeParameter",
+      "insertText": "map<json>"
+    },
+    {
+      "label": "map<string>",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Map"
       },
-      {
-        "label": "byte[]",
-        "labelDetails": {
-          "detail": "Structural Types",
-          "description": "Array"
-        },
-        "kind": "TypeParameter",
-        "insertText": "byte[]"
-      }
-    ]
-  }
+      "kind": "TypeParameter",
+      "insertText": "map<string>"
+    },
+    {
+      "label": "json[]",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Array"
+      },
+      "kind": "TypeParameter",
+      "insertText": "json[]"
+    },
+    {
+      "label": "byte[]",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Array"
+      },
+      "kind": "TypeParameter",
+      "insertText": "byte[]"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/non_existence.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/non_existence.json
@@ -159,7 +159,15 @@
       "kind": "TypeParameter",
       "insertText": "anydata"
     },
-    null,
+    {
+      "label": "record",
+      "labelDetails": {
+        "detail": "Structural Types",
+        "description": "Record"
+      },
+      "kind": "Struct",
+      "insertText": "record"
+    },
     {
       "label": "map<json>",
       "labelDetails": {


### PR DESCRIPTION
## Purpose

The initialization should happen once upon the first request. This PR ensures that the initialization is concurrency-safe.