### PR TITLE
Support type templates in function call templates

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorService.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorService.java
@@ -187,7 +187,13 @@ public class ExpressionEditorService implements ExtendedLanguageServerService {
                         return response;
                     }
                 }
-                response.setTemplate(template + "(${1})");
+                // TODO: Fix this after revamping the API
+                if (request.searchKind() != null && request.searchKind().equals("TYPE")) {
+                    response.setTemplate(template);
+                } else {
+                    response.setTemplate(template + "(${1})");
+                }
+
             } catch (Exception e) {
                 response.setError(e);
             }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/FunctionCallTemplateRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/main/java/io/ballerina/flowmodelgenerator/extension/request/FunctionCallTemplateRequest.java
@@ -23,16 +23,18 @@ import io.ballerina.flowmodelgenerator.core.model.Codedata;
 /**
  * Represents a request for function call template.
  *
- * @param filePath  The file path which contains the expression
- * @param codedata  The code data containing function information
- * @param kind      The kind of template to generate (CURRENT/IMPORT/AVAILABLE)
+ * @param filePath   The file path which contains the expression
+ * @param codedata   The code data containing function information
+ * @param kind       The kind of template to generate (CURRENT/IMPORT/AVAILABLE)
+ * @param searchKind The kind of search to perform (corresponds to SearchCommand.Kind)
  * @since 2.0.0
  */
-public record FunctionCallTemplateRequest(String filePath, Codedata codedata, FunctionCallTemplateKind kind) {
-    
+public record FunctionCallTemplateRequest(String filePath, Codedata codedata, FunctionCallTemplateKind kind,
+                                          String searchKind) {
+
     /**
      * Represents the kind of function call template.
-     * 
+     *
      * @since 2.0.0
      */
     public enum FunctionCallTemplateKind {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionCallTemplateTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionCallTemplateTest.java
@@ -91,9 +91,12 @@ public class FunctionCallTemplateTest extends AbstractLSTest {
         if (offset > -1) {
             template = template.replace("${1}", " ");
         }
+
+        String propertyType = testConfig.searchKind() != null && testConfig.searchKind().equals("TYPE") ?
+                "type" : "expression";
         ExpressionEditorContext.Info info = new ExpressionEditorContext.Info(template, startPosition, offset,
                 variableNode.get("codedata").getAsJsonObject(),
-                variableNode.getAsJsonObject("properties").getAsJsonObject("expression"));
+                variableNode.getAsJsonObject("properties").getAsJsonObject(propertyType));
         ExpressionEditorDiagnosticsRequest diagnosticsRequest =
                 new ExpressionEditorDiagnosticsRequest(sourcePath, info);
         JsonObject response = getResponse(diagnosticsRequest, "expressionEditor/diagnostics");

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionCallTemplateTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/FunctionCallTemplateTest.java
@@ -60,14 +60,14 @@ public class FunctionCallTemplateTest extends AbstractLSTest {
 
         notifyDidOpen(sourcePath);
         FunctionCallTemplateRequest request = new FunctionCallTemplateRequest(sourcePath, testConfig.codedata(),
-                testConfig.kind());
+                testConfig.kind(), testConfig.searchKind());
         String template = getResponse(request).getAsJsonPrimitive("template").getAsString();
         notifyDidClose(sourcePath);
 
         if (!template.equals(testConfig.functionCall())) {
             TestConfig updatedConfig = new TestConfig(testConfig.description(), testConfig.filePath(),
                     testConfig.codedata(),
-                    testConfig.kind(), template);
+                    testConfig.kind(), testConfig.searchKind(), template);
             // updateConfig(configJsonPath, updatedConfig);
             Assert.fail(String.format("Failed test: '%s' (%s)", testConfig.description(), configJsonPath));
         }
@@ -82,7 +82,7 @@ public class FunctionCallTemplateTest extends AbstractLSTest {
         // Call the function call template API
         notifyDidOpen(sourcePath);
         FunctionCallTemplateRequest request = new FunctionCallTemplateRequest(sourcePath, testConfig.codedata(),
-                testConfig.kind());
+                testConfig.kind(), testConfig.searchKind());
         String template = getResponse(request).getAsJsonPrimitive("template").getAsString();
 
         // Call the diagnostics API 
@@ -130,7 +130,8 @@ public class FunctionCallTemplateTest extends AbstractLSTest {
     }
 
     private record TestConfig(String description, String filePath, Codedata codedata,
-                              FunctionCallTemplateRequest.FunctionCallTemplateKind kind, String functionCall) {
+                              FunctionCallTemplateRequest.FunctionCallTemplateKind kind, String searchKind,
+                              String functionCall) {
 
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/type1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/type1.json
@@ -1,0 +1,12 @@
+{
+    "description": "",
+    "filePath": "source.bal",
+    "codedata": {
+      "node": "FUNCTION_CALL",
+      "symbol": "Address"
+    },
+    "kind": "CURRENT",
+    "searchKind": "TYPE",
+    "functionCall": "Address"
+  }
+  

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/type1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/type1.json
@@ -2,11 +2,10 @@
     "description": "",
     "filePath": "source.bal",
     "codedata": {
-      "node": "FUNCTION_CALL",
-      "symbol": "Address"
+        "node": "FUNCTION_CALL",
+        "symbol": "Address"
     },
     "kind": "CURRENT",
     "searchKind": "TYPE",
     "functionCall": "Address"
-  }
-  
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/type2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/type2.json
@@ -2,14 +2,13 @@
     "description": "",
     "filePath": "source.bal",
     "codedata": {
-      "node": "FUNCTION_CALL",
-      "org": "ballerina",
-      "module": "http",
-      "symbol": "ClientConfiguration",
-      "version": "2.14.0"
+        "node": "FUNCTION_CALL",
+        "org": "ballerina",
+        "module": "http",
+        "symbol": "ClientConfiguration",
+        "version": "2.14.0"
     },
     "kind": "IMPORTED",
     "searchKind": "TYPE",
     "functionCall": "http:ClientConfiguration"
-  }
-  
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/type2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/config/type2.json
@@ -1,0 +1,15 @@
+{
+    "description": "",
+    "filePath": "source.bal",
+    "codedata": {
+      "node": "FUNCTION_CALL",
+      "org": "ballerina",
+      "module": "http",
+      "symbol": "ClientConfiguration",
+      "version": "2.14.0"
+    },
+    "kind": "IMPORTED",
+    "searchKind": "TYPE",
+    "functionCall": "http:ClientConfiguration"
+  }
+  

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/source/source.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_call_template/source/source.bal
@@ -1,7 +1,11 @@
 import ballerina/io;
+import ballerina/http;
 
 public function testFunctionCall() {
     int result = 10;
+    http:ClientConfiguration config = {
+        baseUrl: "http://localhost:9090"
+    };
     io:println("Result: ", result);
 }
 


### PR DESCRIPTION
## Purpose


This extends the same implementation of the function browser to the type browser as well.

**NOTE**: This is a temporary solution until the API is properly revamped. Since the correct implementation breaks the whole API, this is introduced as a workaround to work with the existing API.