### PR TITLE
Render the variable node if the expression cannot be derived

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -2047,6 +2047,11 @@ class CodeAnalyzer extends NodeVisitor {
     }
 
     private void handleExpressionNode(NonTerminalNode statementNode) {
+        // If there is a type binding pattern node, then default to the variable node
+        if (typedBindingPatternNode != null) {
+            return;
+        }
+
         startNode(NodeKind.EXPRESSION, statementNode)
                 .properties().statement(statementNode);
     }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call1.json
@@ -76,11 +76,11 @@
       {
         "id": "59685",
         "metadata": {
-          "label": "Custom Expression",
-          "description": "Represents a custom Ballerina expression"
+          "label": "Declare Variable",
+          "description": "Assign a value to a variable"
         },
         "codedata": {
-          "node": "EXPRESSION",
+          "node": "VARIABLE",
           "lineRange": {
             "fileName": "method_call.bal",
             "startLine": {
@@ -96,21 +96,21 @@
         },
         "returning": false,
         "properties": {
-          "statement": {
+          "expression": {
             "metadata": {
-              "label": "Statement",
-              "description": "Ballerina statement"
+              "label": "Expression",
+              "description": "Initialize with value"
             },
             "valueType": "EXPRESSION",
             "value": "new Calculator(10)",
-            "optional": false,
+            "optional": true,
             "editable": true,
             "advanced": false,
             "hidden": false
           },
           "variable": {
             "metadata": {
-              "label": "Variable Name",
+              "label": "Name",
               "description": "Name of the variable"
             },
             "valueType": "IDENTIFIER",
@@ -135,7 +135,7 @@
           },
           "type": {
             "metadata": {
-              "label": "Variable Type",
+              "label": "Type",
               "description": "Type of the variable"
             },
             "valueType": "TYPE",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call_time.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call_time.json
@@ -1,0 +1,200 @@
+{
+  "start": {
+    "line": 2,
+    "offset": 0
+  },
+  "end": {
+    "line": 5,
+    "offset": 1
+  },
+  "source": "method_call_time.bal",
+  "description": "Tests a simple diagram flow",
+  "diagram": {
+    "fileName": "method_call_time.bal",
+    "nodes": [
+      {
+        "id": "35000",
+        "metadata": {
+          "label": "Start"
+        },
+        "codedata": {
+          "node": "EVENT_START",
+          "lineRange": {
+            "fileName": "method_call_time.bal",
+            "startLine": {
+              "line": 2,
+              "offset": 38
+            },
+            "endLine": {
+              "line": 5,
+              "offset": 1
+            }
+          },
+          "sourceCode": "public function main() returns error? {\n    time:Zone timeZone = check time:loadSystemZone();\n    time:ZoneOffset|() offeset = timeZone.fixedOffset();\n}"
+        },
+        "returning": false,
+        "flags": 0
+      },
+      {
+        "id": "34897",
+        "metadata": {
+          "label": "loadSystemZone",
+          "description": "Load the default time zone of the system.\n```ballerina\ntime:Zone|time:Error zone = time:loadSystemZone();\n```",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_time_2.7.0.png"
+        },
+        "codedata": {
+          "node": "FUNCTION_CALL",
+          "org": "ballerina",
+          "module": "time",
+          "symbol": "loadSystemZone",
+          "version": "2.7.0",
+          "lineRange": {
+            "fileName": "method_call_time.bal",
+            "startLine": {
+              "line": 3,
+              "offset": 4
+            },
+            "endLine": {
+              "line": 3,
+              "offset": 53
+            }
+          },
+          "sourceCode": "time:Zone timeZone = check time:loadSystemZone();"
+        },
+        "returning": false,
+        "properties": {
+          "checkError": {
+            "metadata": {
+              "label": "Check Error",
+              "description": "Trigger error flow"
+            },
+            "valueType": "FLAG",
+            "value": true,
+            "optional": false,
+            "editable": true,
+            "advanced": true,
+            "hidden": false
+          },
+          "variable": {
+            "metadata": {
+              "label": "Variable Name",
+              "description": "Name of the variable"
+            },
+            "valueType": "IDENTIFIER",
+            "value": "timeZone",
+            "optional": false,
+            "editable": false,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+              "lineRange": {
+                "fileName": "method_call_time.bal",
+                "startLine": {
+                  "line": 3,
+                  "offset": 14
+                },
+                "endLine": {
+                  "line": 3,
+                  "offset": 22
+                }
+              }
+            }
+          },
+          "type": {
+            "metadata": {
+              "label": "Variable Type",
+              "description": "Type of the variable"
+            },
+            "valueType": "TYPE",
+            "value": "time:Zone",
+            "placeholder": "var",
+            "optional": false,
+            "editable": false,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {}
+          }
+        },
+        "flags": 1
+      },
+      {
+        "id": "35892",
+        "metadata": {
+          "label": "Declare Variable",
+          "description": "Assign a value to a variable"
+        },
+        "codedata": {
+          "node": "VARIABLE",
+          "lineRange": {
+            "fileName": "method_call_time.bal",
+            "startLine": {
+              "line": 4,
+              "offset": 4
+            },
+            "endLine": {
+              "line": 4,
+              "offset": 56
+            }
+          },
+          "sourceCode": "time:ZoneOffset|() offeset = timeZone.fixedOffset();"
+        },
+        "returning": false,
+        "properties": {
+          "expression": {
+            "metadata": {
+              "label": "Expression",
+              "description": "Initialize with value"
+            },
+            "valueType": "EXPRESSION",
+            "value": "timeZone.fixedOffset()",
+            "optional": true,
+            "editable": true,
+            "advanced": false,
+            "hidden": false
+          },
+          "variable": {
+            "metadata": {
+              "label": "Name",
+              "description": "Name of the variable"
+            },
+            "valueType": "IDENTIFIER",
+            "value": "offeset",
+            "optional": false,
+            "editable": false,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {
+              "lineRange": {
+                "fileName": "method_call_time.bal",
+                "startLine": {
+                  "line": 4,
+                  "offset": 23
+                },
+                "endLine": {
+                  "line": 4,
+                  "offset": 30
+                }
+              }
+            }
+          },
+          "type": {
+            "metadata": {
+              "label": "Type",
+              "description": "Type of the variable"
+            },
+            "valueType": "TYPE",
+            "value": "time:ZoneOffset|()",
+            "placeholder": "var",
+            "optional": false,
+            "editable": true,
+            "advanced": false,
+            "hidden": false,
+            "codedata": {}
+          }
+        },
+        "flags": 0
+      }
+    ],
+    "connections": []
+  }
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/method_call_time.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/source/method_call_time.bal
@@ -1,0 +1,6 @@
+import ballerina/time;
+
+public function main() returns error? {
+    time:Zone timeZone = check time:loadSystemZone();
+    time:ZoneOffset|() offeset = timeZone.fixedOffset();
+}


### PR DESCRIPTION
## Purpose


The current implementation renders a custom expression if it cannot determine the expression. With this change, it defaults to the variable node if a type binding pattern node exists.

Related to https://github.com/wso2/product-ballerina-integrator/issues/48