### PR TITLE
Improve the data mapper form

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataMapperBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataMapperBuilder.java
@@ -20,11 +20,9 @@ package io.ballerina.flowmodelgenerator.core.model.node;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
-import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
-import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
@@ -40,7 +38,6 @@ import io.ballerina.projects.Project;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.langserver.common.utils.NameUtil;
-import org.ballerinalang.langserver.common.utils.RecordUtil;
 import org.ballerinalang.langserver.commons.eventsync.exceptions.EventSyncException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
@@ -216,17 +213,7 @@ public class DataMapperBuilder extends NodeBuilder {
             throw new IllegalStateException("Output must be defined for a data mapper node");
         }
 
-        String bodyText = "";
-        Optional<TypeDefinitionSymbol> recordSymbol =
-                sourceBuilder.getTypeDefinitionSymbol(output.get().value().toString());
-        if (recordSymbol.isPresent()) {
-            TypeSymbol typeSymbol = recordSymbol.get().typeDescriptor();
-            if (typeSymbol.typeKind() == TypeDescKind.RECORD) {
-                bodyText =
-                        RecordUtil.getFillAllRecordFieldInsertText(
-                                ((RecordTypeSymbol) typeSymbol).fieldDescriptors());
-            }
-        }
+        String bodyText = sourceBuilder.getExpressionBodyText(output.get().value().toString()).orElse("");
 
         sourceBuilder.token()
                 .keyword(SyntaxKind.FUNCTION_KEYWORD)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataMapperDefinitionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/DataMapperDefinitionBuilder.java
@@ -60,7 +60,8 @@ public class DataMapperDefinitionBuilder extends NodeBuilder {
     private static final String DATA_MAPPINGS_BAL = "data_mappings.bal";
     private static final Gson gson = new Gson();
 
-    public static final String ANYDATA_TYPE = TypeKind.ANYDATA.typeName();
+    public static final String RETURN_TYPE = TypeKind.JSON.typeName();
+    public static final String PARAMETER_TYPE = TypeKind.JSON.typeName();
 
     @Override
     public void setConcreteConstData() {
@@ -82,12 +83,12 @@ public class DataMapperDefinitionBuilder extends NodeBuilder {
 
     public static void setMandatoryProperties(NodeBuilder nodeBuilder, String returnType) {
         nodeBuilder.properties()
-                .returnType(returnType, ANYDATA_TYPE, false)
+                .returnType(returnType, RETURN_TYPE, false)
                 .nestedProperty();
     }
 
     public static void setProperty(FormBuilder<?> formBuilder, String type, String name, Token token) {
-        formBuilder.parameter(type, name, token, Property.ValueType.TYPE, TypeKind.ANYDATA.typeName());
+        formBuilder.parameter(type, name, token, Property.ValueType.TYPE, PARAMETER_TYPE);
     }
 
     public static void setOptionalProperties(NodeBuilder nodeBuilder) {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def1.json
@@ -56,7 +56,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "anydata",
+        "valueTypeConstraint": "json",
         "value": "Employee",
         "optional": false,
         "editable": true,
@@ -82,7 +82,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "anydata",
+              "valueTypeConstraint": "json",
               "value": "",
               "optional": false,
               "editable": true,
@@ -121,7 +121,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "Person",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def2.json
@@ -56,7 +56,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "anydata",
+        "valueTypeConstraint": "json",
         "value": "Employee",
         "optional": false,
         "editable": true,
@@ -82,7 +82,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "anydata",
+              "valueTypeConstraint": "json",
               "value": "",
               "optional": false,
               "editable": true,
@@ -121,7 +121,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "string",
                 "optional": false,
                 "editable": true,
@@ -172,7 +172,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "int",
                 "optional": false,
                 "editable": true,
@@ -223,7 +223,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "decimal",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def3.json
@@ -56,7 +56,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "anydata",
+        "valueTypeConstraint": "json",
         "value": "Summary",
         "optional": false,
         "editable": true,
@@ -82,7 +82,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "anydata",
+              "valueTypeConstraint": "json",
               "value": "",
               "optional": false,
               "editable": true,
@@ -121,7 +121,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "Employee[]",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def4.json
@@ -56,7 +56,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "anydata",
+        "valueTypeConstraint": "json",
         "value": "Person",
         "optional": false,
         "editable": true,
@@ -82,7 +82,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "anydata",
+              "valueTypeConstraint": "json",
               "value": "",
               "optional": false,
               "editable": true,
@@ -121,7 +121,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "string",
                 "optional": false,
                 "editable": true,
@@ -172,7 +172,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "string",
                 "optional": false,
                 "editable": true,
@@ -223,7 +223,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "Address",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def5.json
@@ -56,7 +56,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "anydata",
+        "valueTypeConstraint": "json",
         "value": "Employee",
         "optional": false,
         "editable": true,
@@ -82,7 +82,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "anydata",
+              "valueTypeConstraint": "json",
               "value": "",
               "optional": false,
               "editable": true,
@@ -121,7 +121,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "Person",
                 "optional": false,
                 "editable": true,
@@ -172,7 +172,7 @@
                   "description": "Type of the parameter"
                 },
                 "valueType": "TYPE",
-                "valueTypeConstraint": "anydata",
+                "valueTypeConstraint": "json",
                 "value": "Admission",
                 "optional": false,
                 "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-main.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-main.json
@@ -38,7 +38,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "anydata",
+        "valueTypeConstraint": "json",
         "value": "",
         "optional": false,
         "editable": true,
@@ -64,7 +64,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "anydata",
+              "valueTypeConstraint": "json",
               "value": "",
               "optional": false,
               "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-service.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-service.json
@@ -38,7 +38,7 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "anydata",
+        "valueTypeConstraint": "json",
         "value": "",
         "optional": false,
         "editable": true,
@@ -64,7 +64,7 @@
                 "description": "Type of the parameter"
               },
               "valueType": "TYPE",
-              "valueTypeConstraint": "anydata",
+              "valueTypeConstraint": "json",
               "value": "",
               "optional": false,
               "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/data_mapper1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/data_mapper1.json
@@ -84,7 +84,7 @@
             "character": 2
           }
         },
-        "newText": "function transformToPerson(string name, string email, Address address) returns Person => {\n    address: {houseNo: \"\", line1: \"\", line2: \"\", city: \"\", country: \"\"},\n    name: \"\",\n    email: \"\"\n};"
+        "newText": "function transformToPerson(string name, string email, Address address) returns Person => {\n    {\n        address: {houseNo: \"\", line1: \"\", line2: \"\", city: \"\", country: \"\"},\n        name: \"\",\n        email: \"\"\n    }\n};"
       }
     ]
   }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/data_mapper_definition6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/data_mapper_definition6.json
@@ -2,7 +2,7 @@
   "source": "data_mapper/data_mappings.bal",
   "description": "Sample diagram node",
   "diagram": {
-    "id": "69496",
+    "id": "37778",
     "metadata": {
       "label": "Data Mapper",
       "description": "Define a data mapper"
@@ -19,7 +19,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
-        "value": "mapNames",
+        "value": "transformToEmployee",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -30,8 +30,8 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "record",
-        "value": "Summary",
+        "valueTypeConstraint": "json",
+        "value": "string",
         "optional": true,
         "editable": true,
         "advanced": false
@@ -78,7 +78,7 @@
           "advanced": false
         },
         "value": {
-          "employees": {
+          "person": {
             "metadata": {
               "label": "Parameter",
               "description": "Function parameter"
@@ -92,7 +92,7 @@
                 },
                 "valueType": "TYPE",
                 "valueTypeConstraint": "anydata",
-                "value": "Employee[]",
+                "value": "Person",
                 "optional": false,
                 "editable": true,
                 "advanced": false
@@ -103,7 +103,42 @@
                   "description": "Name of the variable"
                 },
                 "valueType": "IDENTIFIER",
-                "value": "employees",
+                "value": "person",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "admission": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "Admission",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "admission",
                 "optional": false,
                 "editable": true,
                 "advanced": false
@@ -134,7 +169,7 @@
             "character": 0
           }
         },
-        "newText": "\nfunction mapNames(Employee []employees) returns Summary=> {\ntotalSalary: 0, averageAge: ()\n};"
+        "newText": "\nfunction transformToEmployee(Person person, Admission admission) returns string=> \"\";"
       }
     ]
   }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/data_mapper_definition7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/data_mapper_definition7.json
@@ -2,7 +2,7 @@
   "source": "data_mapper/data_mappings.bal",
   "description": "Sample diagram node",
   "diagram": {
-    "id": "69496",
+    "id": "37778",
     "metadata": {
       "label": "Data Mapper",
       "description": "Define a data mapper"
@@ -19,7 +19,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
-        "value": "mapNames",
+        "value": "transformToEmployee",
         "optional": false,
         "editable": true,
         "advanced": false
@@ -30,8 +30,8 @@
           "description": "Type of the return value"
         },
         "valueType": "TYPE",
-        "valueTypeConstraint": "record",
-        "value": "Summary",
+        "valueTypeConstraint": "json",
+        "value": "float",
         "optional": true,
         "editable": true,
         "advanced": false
@@ -78,7 +78,7 @@
           "advanced": false
         },
         "value": {
-          "employees": {
+          "person": {
             "metadata": {
               "label": "Parameter",
               "description": "Function parameter"
@@ -92,7 +92,7 @@
                 },
                 "valueType": "TYPE",
                 "valueTypeConstraint": "anydata",
-                "value": "Employee[]",
+                "value": "Person",
                 "optional": false,
                 "editable": true,
                 "advanced": false
@@ -103,7 +103,42 @@
                   "description": "Name of the variable"
                 },
                 "valueType": "IDENTIFIER",
-                "value": "employees",
+                "value": "person",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false
+          },
+          "admission": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "TYPE",
+                "valueTypeConstraint": "anydata",
+                "value": "Admission",
+                "optional": false,
+                "editable": true,
+                "advanced": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "admission",
                 "optional": false,
                 "editable": true,
                 "advanced": false
@@ -134,7 +169,7 @@
             "character": 0
           }
         },
-        "newText": "\nfunction mapNames(Employee []employees) returns Summary=> {\ntotalSalary: 0, averageAge: ()\n};"
+        "newText": "\nfunction transformToEmployee(Person person, Admission admission) returns float=> 0.0;"
       }
     ]
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=2.2.0-SNAPSHOT
-ballerinaLangVersion=2201.12.3-20250331-225900-54db2e53
+ballerinaLangVersion=2201.12.3-20250403-133600-d3b2acb4
 
 ballerinaGradlePluginVersion=2.3.0
 checkStyleToolVersion=10.12.1


### PR DESCRIPTION
## Purpose


The PR addresses the following changes:

1. Restricts to only allow subtypes of JSON values in the type constraint, so users won't see unsupported types in the completions.
2. Allow saving primitive types in the data mapper

Fixes https://github.com/wso2/product-ballerina-integrator/issues/17
Fixes https://github.com/wso2/product-ballerina-integrator/issues/96