### PR TITLE
Set the type constraint for the identifiers in the global and object scope

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/FormBuilder.java
@@ -288,6 +288,7 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
                     .stepOut()
                 .value(data)
                 .type(Property.ValueType.IDENTIFIER)
+                .typeConstraint(Property.GLOBAL_SCOPE)
                 .editable();
         addProperty(Property.VARIABLE_KEY);
         return this;
@@ -742,6 +743,7 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
                     .description(FunctionDefinitionBuilder.FUNCTION_NAME_DOC)
                     .stepOut()
                 .type(Property.ValueType.IDENTIFIER)
+                .typeConstraint(Property.GLOBAL_SCOPE)
                 .value(functionName);
 
         if (!functionName.equals(Constants.MAIN_FUNCTION_NAME)) {
@@ -768,6 +770,7 @@ public class FormBuilder<T> extends FacetedBuilder<T> {
                     .stepOut()
                 .value(generatedName)
                 .type(Property.ValueType.IDENTIFIER)
+                .typeConstraint(Property.GLOBAL_SCOPE)
                 .editable();
         addProperty(Property.FUNCTION_NAME_KEY);
         return this;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -160,6 +160,7 @@ public record Property(Metadata metadata, String valueType, Object valueTypeCons
     public static final String SCOPE_DOC = "Scope of the connection, Global or Local";
     public static final String GLOBAL_SCOPE = "Global";
     public static final String SERVICE_SCOPE = "Service";
+    public static final String OBJECT_SCOPE = "Object";
     public static final String LOCAL_SCOPE = "Local";
 
     public static final String CONNECTION_KEY = "connection";

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AutomationBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AutomationBuilder.java
@@ -90,6 +90,7 @@ public class AutomationBuilder extends FunctionDefinitionBuilder {
                     .stepOut()
                 .value(MAIN_FUNCTION_NAME)
                 .type(Property.ValueType.IDENTIFIER)
+                .typeConstraint(Property.GLOBAL_SCOPE)
                 .hidden()
                 .stepOut()
                 .addProperty(Property.FUNCTION_NAME_KEY);

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config1.json
@@ -34,6 +34,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -42,10 +43,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config1",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -56,7 +59,8 @@
           "value": "",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0
@@ -94,6 +98,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -102,10 +107,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config2",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -116,7 +123,8 @@
           "value": "",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config2.json
@@ -34,6 +34,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -42,10 +43,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config1",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -56,7 +59,8 @@
           "value": "10",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0
@@ -94,6 +98,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -102,10 +107,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config2",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -116,7 +123,8 @@
           "value": "",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config3.json
@@ -34,6 +34,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -42,10 +43,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config1",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -56,7 +59,8 @@
           "value": "10",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0
@@ -94,6 +98,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -102,10 +107,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config2",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -116,7 +123,8 @@
           "value": "\"new config\"",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config4.json
@@ -34,6 +34,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -42,10 +43,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config3",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -56,7 +59,8 @@
           "value": "10",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0
@@ -94,6 +98,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -102,10 +107,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config4",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -116,7 +123,8 @@
           "value": "\"new config\"",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0
@@ -154,6 +162,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -162,10 +171,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config1",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -176,7 +187,8 @@
           "value": "10",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0
@@ -214,6 +226,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -222,10 +235,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config2",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -236,7 +251,8 @@
           "value": "\"new config\"",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/configurable_variables/config/config5.json
@@ -34,6 +34,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -42,10 +43,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config3",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -56,7 +59,8 @@
           "value": "10",
           "optional": true,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         }
       },
       "flags": 0
@@ -94,6 +98,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -102,10 +107,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config4",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -117,6 +124,7 @@
           "optional": true,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "diagnostics": {
             "hasDiagnostics": true,
             "diagnostics": [
@@ -166,6 +174,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -174,10 +183,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config1",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -189,6 +200,7 @@
           "optional": true,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "diagnostics": {
             "hasDiagnostics": true,
             "diagnostics": [
@@ -238,6 +250,7 @@
           "optional": false,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "codedata": {}
         },
         "variable": {
@@ -246,10 +259,12 @@
             "description": "Name of the variable"
           },
           "valueType": "IDENTIFIER",
+          "valueTypeConstraint": "Global",
           "value": "config2",
           "optional": false,
           "editable": true,
-          "advanced": false
+          "advanced": false,
+          "hidden": false
         },
         "defaultable": {
           "metadata": {
@@ -261,6 +276,7 @@
           "optional": true,
           "editable": true,
           "advanced": false,
+          "hidden": false,
           "diagnostics": {
             "hasDiagnostics": true,
             "diagnostics": [

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier1.json
@@ -1,0 +1,43 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "fn",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 35
+        },
+        "end": {
+          "line": 15,
+          "character": 37
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2008"
+      },
+      "message": "redeclared symbol 'fn'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier2.json
@@ -1,0 +1,25 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "http",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier3.json
@@ -1,0 +1,25 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "classVar",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier4.json
@@ -1,0 +1,43 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "port",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 35
+        },
+        "end": {
+          "line": 15,
+          "character": 39
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2008"
+      },
+      "message": "redeclared symbol 'port'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier5.json
@@ -1,0 +1,43 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "MyRecord",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 35
+        },
+        "end": {
+          "line": 15,
+          "character": 43
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2008"
+      },
+      "message": "redeclared symbol 'MyRecord'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier6.json
@@ -1,0 +1,43 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "MyError",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 35
+        },
+        "end": {
+          "line": 15,
+          "character": 42
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2008"
+      },
+      "message": "redeclared symbol 'MyError'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier7.json
@@ -1,0 +1,43 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "MyEnum",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 35
+        },
+        "end": {
+          "line": 15,
+          "character": 41
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2008"
+      },
+      "message": "redeclared symbol 'MyEnum'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier8.json
@@ -1,0 +1,43 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "httpClient",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 35
+        },
+        "end": {
+          "line": 15,
+          "character": 45
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2008"
+      },
+      "message": "redeclared symbol 'httpClient'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/module_identifier9.json
@@ -1,0 +1,43 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "EN_B",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Global",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 35
+        },
+        "end": {
+          "line": 15,
+          "character": 39
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2008"
+      },
+      "message": "redeclared symbol 'EN_B'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/object_identifier1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/object_identifier1.json
@@ -1,0 +1,25 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "fn",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Object",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/object_identifier2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/object_identifier2.json
@@ -1,0 +1,60 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "lock",
+    "startLine": {
+      "line": 15,
+      "offset": 35
+    },
+    "offset": 2,
+    "property": {
+      "metadata": {
+        "label": "Name",
+        "description": "Name of the variable"
+      },
+      "valueType": "IDENTIFIER",
+      "valueTypeConstraint": "Object",
+      "value": "i",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 4
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE0600"
+      },
+      "message": "invalid token 'lock'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 1
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE0400"
+      },
+      "message": "missing identifier"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/source/source.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/source/source.bal
@@ -35,3 +35,8 @@ function serviceCall() {
 }
 
 type MyError distinct error;
+
+enum MyEnum {
+    EN_A,
+    EN_B
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def1.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "main",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def2.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "main",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/automation_def3.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "main",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def1.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "mapPersonToEmployee",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def2.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "createEmployee",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def3.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "mapNames",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def4.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "transformToPerson",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/data_mapper_def5.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "transformToEmployee",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def1.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "simpleFunction",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def10.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "'from",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def11.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "ව",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def13.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def13.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "foo",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def14.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def14.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "divide",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def2.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "add",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def3.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "greet",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def4.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "sum",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def5.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "complexFunction",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def6.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "divide",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def7.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "getCounter",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def8.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "processUser",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/function_definition/config/function_def9.json
@@ -31,6 +31,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "\\$dollar\\#hash",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/automation_definition.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/automation_definition.json
@@ -21,6 +21,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "main",
         "optional": false,
         "editable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-main.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-main.json
@@ -26,6 +26,7 @@
           "description": "Name of the data mapper"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "transform1",
         "optional": false,
         "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-service.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/data_mapper-service.json
@@ -26,6 +26,7 @@
           "description": "Name of the data mapper"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "transform1",
         "optional": false,
         "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_definition.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/function_definition.json
@@ -21,6 +21,7 @@
           "description": "Name of the function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "function1",
         "optional": false,
         "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/np_functions/np_function_definition.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/np_functions/np_function_definition.json
@@ -23,6 +23,7 @@
           "description": "Name of the natural function"
         },
         "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "Global",
         "value": "naturalFunction",
         "optional": false,
         "editable": true,


### PR DESCRIPTION
## Purpose


Set the scope as the type constraint in the identifier property, allowing the language server to perform validation based on visible variables in that scope.

This enables validation for both module-level and object-level definitions.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/92