### PR TITLE
Support creating listener with default configurations for all listener types

### DIFF
--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/OpenApiServiceGenerator.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/OpenApiServiceGenerator.java
@@ -33,7 +33,6 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
-import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.openapi.core.generators.common.GeneratorUtils;
@@ -113,7 +112,8 @@ public class OpenApiServiceGenerator {
         this.workspaceManager = workspaceManager;
     }
 
-    public Map<String, List<TextEdit>> generateService(Service service, boolean isDefaultListenerCreationRequired)
+    public Map<String, List<TextEdit>> generateService(Service service, ListenerUtil.DefaultListener
+            defaultListener)
             throws IOException,
             BallerinaOpenApiException, FormatterException, WorkspaceDocumentException, EventSyncException {
         Filter filter = new Filter(new ArrayList<>(), new ArrayList<>());
@@ -154,17 +154,9 @@ public class OpenApiServiceGenerator {
                 textEdits.add(new TextEdit(Utils.toRange(modulePartNode.lineRange().startLine()), importText));
             }
 
-            if (isDefaultListenerCreationRequired) {
-                List<ImportDeclarationNode> importsList = modulePartNode.imports().stream().toList();
-                LinePosition listenerDeclaringLoc;
-                if (!importsList.isEmpty()) {
-                    listenerDeclaringLoc = importsList.get(importsList.size() - 1).lineRange().endLine();
-                } else {
-                    listenerDeclaringLoc = modulePartNode.lineRange().endLine();
-                }
-                String listenerDeclarationStmt = ListenerUtil.getHttpDefaultListenerDeclarationStmt(
-                        semanticModel.get(), document.get(), listenerDeclaringLoc);
-                textEdits.add(new TextEdit(Utils.toRange(listenerDeclaringLoc), listenerDeclarationStmt));
+            if (Objects.nonNull(defaultListener)) {
+                String stmt = ListenerUtil.getDefaultListenerDeclarationStmt(defaultListener);
+                textEdits.add(new TextEdit(Utils.toRange(defaultListener.linePosition()), stmt));
             }
 
             StringBuilder serviceBuilder = new StringBuilder();

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
@@ -45,6 +45,7 @@ public class ServiceModelGeneratorConstants {
             "listener http:Listener %s = http:getDefaultListener();" + NEW_LINE;
     public static final String HTTP_DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use the default HTTP listener" +
             " (port: 9090)";
+    public static final String DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use a %s listener with default configurations";
     public static final String HTTP_DEFAULT_LISTENER_VAR_NAME = "httpDefaultListener";
     public static final String HTTP_DEFAULT_LISTENER_EXPR = "http:getDefaultListener()";
 

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
@@ -40,20 +40,25 @@ public class ServiceModelGeneratorConstants {
 
     public static final String SINGLE_SELECT_VALUE = "SINGLE_SELECT";
     public static final String MULTIPLE_SELECT_VALUE = "MULTIPLE_SELECT";
-
-    public static final String HTTP_DEFAULT_LISTENER_STMT = NEW_LINE +
-            "listener http:Listener %s = http:getDefaultListener();" + NEW_LINE;
     public static final String HTTP_DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use the default HTTP listener" +
             " (port: 9090)";
-    public static final String DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use a %s listener with default configurations";
-    public static final String HTTP_DEFAULT_LISTENER_VAR_NAME = "httpDefaultListener";
-    public static final String HTTP_DEFAULT_LISTENER_EXPR = "http:getDefaultListener()";
+    public static final String DEFAULT_LISTENER_ITEM_LABEL = "(+) Create and use a %s listener with " +
+            "default configurations";
+    public static final String DEFAULT_LISTENER_VAR_NAME = "%sDefaultListener";
 
-    public static final String KAFKA = "kafka";
     public static final String HTTP = "http";
     public static final String GRAPHQL = "graphql";
     public static final String TCP = "tcp";
+
+    public static final String KAFKA = "kafka";
     public static final String RABBITMQ = "rabbitmq";
+    public static final String MQTT = "mqtt";
+    public static final String ASB = "asb";
+    public static final String SF = "salesforce";
+    public static final String TRIGGER_GITHUB = "trigger.github";
+
+    public static final String FTP = "ftp";
+    public static final String FILE = "file";
 
     public static final String PROPERTY_REQUIRED_FUNCTIONS = "requiredFunctions";
     public static final String PROPERTY_DESIGN_APPROACH = "designApproach";
@@ -89,6 +94,25 @@ public class ServiceModelGeneratorConstants {
 
     public static final String TYPE_HTTP_SERVICE_CONFIG = "http:ServiceConfig";
 
+
+    // protocol listeners
+    public static final String HTTP_DEFAULT_LISTENER_EXPR = "http:getDefaultListener()";
+    public static final String GRAPHQL_DEFAULT_LISTENER_EXPR = "new (listenTo = 8080)";
+    public static final String TCP_DEFAULT_LISTENER_EXPR = "new (localPort = 8080)";
+
+    // event listeners
+    public static final String KAFKA_DEFAULT_LISTENER_EXPR = "new (bootstrapServers = \"\")";
+    public static final String RABBITMQ_DEFAULT_LISTENER_EXPR = "new (host = \"localhost\", port = 5672)";
+    public static final String MQTT_DEFAULT_LISTENER_EXPR = "new(\"tcp://localhost:1883\", \"listener-unique-id\", " +
+            "\"mqtt/topic\")";
+    public static final String ASB_DEFAULT_LISTENER_EXPR = "new (connectionString = \"\", " +
+            "entityConfig = {queueName: \"test-queue\"}, autoComplete = false)";
+    public static final String SF_DEFAULT_LISTENER_EXPR = "new (auth = {username: \"\", password: \"\"})";
+    public static final String GITHUB_DEFAULT_LISTENER_EXPR = "new ()";
+
+    // file listeners
+    public static final String FTP_DEFAULT_LISTENER_EXPR = "new ()";
+    public static final String FILE_DEFAULT_LISTENER_EXPR = "new (path = \"\")";
 
     public static final MetaData SERCVICE_CLASS_NAME_METADATA = new MetaData("Class Name",
             "The name of the class definition");

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerUtil.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerUtil.java
@@ -152,7 +152,7 @@ public class ListenerUtil {
             listeners.add(HTTP_DEFAULT_LISTENER_ITEM_LABEL);
         }
 
-        if (!isHttp && listeners.isEmpty()) {
+        if (!isHttp && !moduleName.equals("ai") && listeners.isEmpty()) {
             listeners.add(DEFAULT_LISTENER_ITEM_LABEL.formatted(moduleName(moduleName)));
         }
 

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerUtil.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerUtil.java
@@ -64,6 +64,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.DEFAULT_LISTENER_ITEM_LABEL;
+import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_ITEM_LABEL;
 import static io.ballerina.servicemodelgenerator.extension.util.Utils.removeLeadingSingleQuote;
 import static io.ballerina.servicemodelgenerator.extension.util.Utils.upperCaseFirstLetter;
 
@@ -122,7 +124,11 @@ public class ListenerUtil {
         }
 
         if (isHttp && !isHttpDefaultListenerDefined) {
-            listeners.add(ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_ITEM_LABEL);
+            listeners.add(HTTP_DEFAULT_LISTENER_ITEM_LABEL);
+        }
+
+        if (!isHttp && listeners.isEmpty()) {
+            listeners.add(DEFAULT_LISTENER_ITEM_LABEL.formatted(moduleName));
         }
 
         return listeners;
@@ -179,7 +185,7 @@ public class ListenerUtil {
                 }};
                 for (int i = 0; i < values.size(); i++) {
                     if (values.get(i).equals(
-                            ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_ITEM_LABEL)) {
+                            HTTP_DEFAULT_LISTENER_ITEM_LABEL)) {
                         valuesList.set(i, ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_VAR_NAME);
                         listener.setValues(valuesList);
                         return true;
@@ -187,7 +193,7 @@ public class ListenerUtil {
                 }
             } else {
                 if (listener.getValue().equals(
-                        ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_ITEM_LABEL)) {
+                        HTTP_DEFAULT_LISTENER_ITEM_LABEL)) {
                     listener.setValue(ServiceModelGeneratorConstants.HTTP_DEFAULT_LISTENER_VAR_NAME);
                     return true;
                 }

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_service/config/add_graphql_service_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/add_service/config/add_graphql_service_2.json
@@ -1,0 +1,190 @@
+{
+  "filePath": "sample1/main.bal",
+  "description": "Test adding a rabbitmq service",
+  "service": {
+    "id": "2",
+    "name": "GraphQL Service",
+    "type": "graphql",
+    "displayName": "GraphQL Service",
+    "description": "Add the service documentation",
+    "displayAnnotation": {
+      "label": "GraphQL Service",
+      "iconPath": "https://bcentral-packageicons.azureedge.net/images/ballerina_graphql_1.15.0.png"
+    },
+    "moduleName": "graphql",
+    "orgName": "ballerina",
+    "version": "1.15.0",
+    "packageName": "graphql",
+    "listenerProtocol": "graphql",
+    "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_graphql_1.15.0.png",
+    "properties": {
+      "listener": {
+        "metadata": {
+          "label": "Listeners",
+          "description": "The Listeners to be bound with the service"
+        },
+        "enabled": true,
+        "editable": true,
+        "value": "(+) Create and use a graphql listener with default configurations",
+        "values": [],
+        "valueType": "MULTIPLE_SELECT",
+        "valueTypeConstraint": "graphql:Listener",
+        "isType": false,
+        "placeholder": "",
+        "optional": false,
+        "advanced": false,
+        "items": [
+          "(+) Create and use a graphql listener with default configurations"
+        ],
+        "codedata": {
+          "inListenerInit": false,
+          "isBasePath": false,
+          "inDisplayAnnotation": false,
+          "type": "LISTENER"
+        },
+        "addNewButton": true
+      },
+      "serviceType": {
+        "metadata": {
+          "label": "GraphQL Service Type",
+          "description": "The name of the service contract type"
+        },
+        "enabled": false,
+        "editable": true,
+        "value": "Service",
+        "valueType": "SINGLE_SELECT",
+        "valueTypeConstraint": "string",
+        "isType": false,
+        "placeholder": "Service",
+        "optional": false,
+        "advanced": false,
+        "items": [
+          "",
+          "Service"
+        ],
+        "codedata": {
+          "inListenerInit": false,
+          "isBasePath": false,
+          "inDisplayAnnotation": false,
+          "type": "SERVICE_TYPE"
+        },
+        "addNewButton": false
+      },
+      "basePath": {
+        "metadata": {
+          "label": "Service Base Path",
+          "description": "The base path of the service"
+        },
+        "enabled": true,
+        "editable": true,
+        "value": "/graphql",
+        "values": [],
+        "valueType": "IDENTIFIER",
+        "valueTypeConstraint": "string",
+        "isType": false,
+        "placeholder": "/graphql",
+        "optional": false,
+        "advanced": false,
+        "codedata": {
+          "inListenerInit": false,
+          "isBasePath": false,
+          "inDisplayAnnotation": false,
+          "type": "SERVICE_BASE_PATH"
+        },
+        "addNewButton": false
+      },
+      "annotServiceConfig": {
+        "metadata": {
+          "label": "Service Configuration",
+          "description": "Configurations for the Graphql service"
+        },
+        "enabled": true,
+        "editable": true,
+        "value": "{\n    introspection: false\n}",
+        "values": [],
+        "valueType": "EXPRESSION",
+        "valueTypeConstraint": "graphql:GraphqlServiceConfig",
+        "isType": false,
+        "placeholder": "{}",
+        "optional": true,
+        "advanced": true,
+        "codedata": {
+          "inListenerInit": false,
+          "isBasePath": false,
+          "inDisplayAnnotation": false,
+          "type": "ANNOTATION_ATTACHMENT",
+          "originalName": "ServiceConfig"
+        },
+        "addNewButton": false,
+        "typeMembers": [
+          {
+            "type": "GraphqlServiceConfig",
+            "packageInfo": "ballerina:graphql:1.15.0",
+            "kind": "RECORD_TYPE",
+            "selected": true
+          }
+        ]
+      }
+    },
+    "codedata": {
+      "lineRange": {
+        "fileName": "main.bal",
+        "startLine": {
+          "line": 17,
+          "offset": 0
+        },
+        "endLine": {
+          "line": 59,
+          "offset": 1
+        }
+      },
+      "inListenerInit": false,
+      "isBasePath": false,
+      "inDisplayAnnotation": false
+    },
+    "functions": []
+  },
+  "output": {
+    "sample1/main.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "\nimport ballerina/graphql;\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "\nlistener graphql:Listener graphqlDefaultListener = new (listenTo = 8080);\n"
+      },
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "\n@graphql:ServiceConfig{\n    introspection: false\n}\nservice /graphql on graphqlDefaultListener {\n\n}"
+      }
+    ]
+  }
+}

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/graphql_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/graphql_service_model.json
@@ -37,7 +37,9 @@
           "placeholder": "",
           "optional": false,
           "advanced": false,
-          "items": [],
+          "items": [
+            "(+) Create and use a graphql listener with default configurations"
+          ],
           "codedata": {
             "inListenerInit": false,
             "isBasePath": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/kafka_service_model_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/kafka_service_model_2.json
@@ -37,7 +37,9 @@
           "placeholder": "",
           "optional": false,
           "advanced": false,
-          "items": [],
+          "items": [
+            "(+) Create and use a kafka listener with default configurations"
+          ],
           "codedata": {
             "inListenerInit": false,
             "isBasePath": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/rabbitmq_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/rabbitmq_service_model.json
@@ -37,7 +37,9 @@
           "placeholder": "",
           "optional": false,
           "advanced": false,
-          "items": [],
+          "items": [
+            "(+) Create and use a rabbitmq listener with default configurations"
+          ],
           "codedata": {
             "inListenerInit": false,
             "isBasePath": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/tcp_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/tcp_service_model.json
@@ -37,7 +37,9 @@
           "placeholder": "",
           "optional": false,
           "advanced": false,
-          "items": [],
+          "items": [
+            "(+) Create and use a tcp listener with default configurations"
+          ],
           "codedata": {
             "inListenerInit": false,
             "isBasePath": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/kafka_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/kafka_service_model.json
@@ -42,6 +42,7 @@
         "optional": false,
         "advanced": false,
         "items": [
+          "(+) Create and use a kafka listener with default configurations",
           "kafkaListener"
         ],
         "codedata": {


### PR DESCRIPTION
## Purpose
$subject

Fixes [#issue](https://github.com/wso2/product-ballerina-integrator/issues/99)

## Approach
Once use select the `(+) Create and use a %s listener with default configurations` option we will create a default listener for selected service type and attach the created listener to the service.

Here are the listener decelerations for each listener
```ballerina
listener http:Listener httpDefaultListener = http:getDefaultListener();
listener graphql:Listener graphqlDefaultListener = new (listenTo = 8080);
listener tcp:Listener tcpDefaultListener = new (localPort = 8080);

listener github:Listener githubDefaultListener = new ();
listener salesforce:Listener salesforceDefaultListener = new (auth = {username: "", password: ""});
listener asb:Listener asbDefaultListener = new (connectionString = "", entityConfig = {queueName: "test-queue"}, autoComplete = false);
listener mqtt:Listener mqttDefaultListener = new ("tcp://localhost:1883", "listener-unique-id", "mqtt/topic");
listener rabbitmq:Listener rabbitmqDefaultListener = new (host = "localhost", port = 5672);
listener kafka:Listener kafkaDefaultListener = new (bootstrapServers = "");

listener file:Listener fileDefaultListener = new (path = "");
listener ftp:Listener ftpDefaultListener = new ();
``` 

https://github.com/user-attachments/assets/b5ba64a3-5964-4bb5-8988-963f8c3573af


