### PR TITLE
Add parameters and return type to metadata

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Metadata.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Metadata.java
@@ -88,6 +88,14 @@ public record Metadata(String label, String description, List<String> keywords, 
             return this;
         }
 
+        public Builder<T> data(String key, Object value) {
+            if (data == null) {
+                data = new LinkedHashMap<>();
+            }
+            data.put(key, value);
+            return this;
+        }
+
         public Builder<T> data(Map<String, Object> data) {
             this.data = data;
             return this;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/FunctionDefinitionBuilder.java
@@ -52,6 +52,9 @@ public class FunctionDefinitionBuilder extends NodeBuilder {
     public static final String PARAMETERS_LABEL = "Parameters";
     public static final String PARAMETERS_DOC = "Function parameters";
 
+    public static final String METADATA_RETURN_KEY = "return";
+    public static final String METADATA_PARAMETERS_KEY = "parameters";
+
     private static final Gson gson = new Gson();
 
     public static Property getParameterSchema() {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign5.json
@@ -15,7 +15,13 @@
       {
         "id": "54375",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int amount"
+            ],
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/clients1.json
@@ -15,7 +15,10 @@
       {
         "id": "46315",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment1.json
@@ -15,7 +15,10 @@
       {
         "id": "33419",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "int"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment10.json
@@ -15,7 +15,12 @@
       {
         "id": "119692",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int i"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment11.json
@@ -15,7 +15,12 @@
       {
         "id": "130449",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int i"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment13.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment13.json
@@ -15,7 +15,12 @@
       {
         "id": "146848",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int i"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment5.json
@@ -15,7 +15,12 @@
       {
         "id": "62280",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int i"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment6.json
@@ -15,7 +15,12 @@
       {
         "id": "78989",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int i"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment7.json
@@ -15,7 +15,12 @@
       {
         "id": "90862",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int i"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment9.json
@@ -15,7 +15,10 @@
       {
         "id": "111167",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/currency_converter1.json
@@ -15,7 +15,15 @@
       {
         "id": "51465",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string 'from",
+              "string to",
+              "decimal amount"
+            ],
+            "return": "json|http:InternalServerError"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics1.json
@@ -15,7 +15,12 @@
       {
         "id": "33450",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string c"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics4.json
@@ -15,7 +15,10 @@
       {
         "id": "36116",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler3.json
@@ -15,7 +15,10 @@
       {
         "id": "64392",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler4.json
@@ -15,7 +15,10 @@
       {
         "id": "37201",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler5.json
@@ -15,7 +15,10 @@
       {
         "id": "45137",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler6.json
@@ -15,7 +15,10 @@
       {
         "id": "53104",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags1.json
@@ -15,7 +15,10 @@
       {
         "id": "36147",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/flags2.json
@@ -15,7 +15,14 @@
       {
         "id": "48923",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "ftp:Caller caller",
+              "ftp:WatchEvent & readonly event"
+            ],
+            "return": "ftp:Error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/force_assign_function.json
@@ -15,7 +15,13 @@
       {
         "id": "55154",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string payload"
+            ],
+            "return": "Apple|jsondata:Error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach3.json
@@ -15,7 +15,10 @@
       {
         "id": "47586",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach4.json
@@ -15,7 +15,10 @@
       {
         "id": "56514",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach5.json
@@ -15,7 +15,10 @@
       {
         "id": "65070",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork1.json
@@ -15,7 +15,10 @@
       {
         "id": "37821",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork2.json
@@ -15,7 +15,10 @@
       {
         "id": "56979",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork3.json
@@ -15,7 +15,10 @@
       {
         "id": "76478",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string[]"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork4.json
@@ -15,7 +15,10 @@
       {
         "id": "97744",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string[]"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork5.json
@@ -15,7 +15,10 @@
       {
         "id": "122296",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/fork6.json
@@ -15,7 +15,10 @@
       {
         "id": "143810",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-json1.json
@@ -15,7 +15,13 @@
       {
         "id": "55154",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string payload"
+            ],
+            "return": "Apple|jsondata:Error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/function_call-log1.json
@@ -15,7 +15,12 @@
       {
         "id": "41390",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event1.json
@@ -15,7 +15,10 @@
       {
         "id": "42182",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "Menu"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event2.json
@@ -15,7 +15,10 @@
       {
         "id": "43523",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "Menu"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/http_api_event3.json
@@ -15,7 +15,12 @@
       {
         "id": "46009",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string item"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if1.json
@@ -15,7 +15,12 @@
       {
         "id": "47311",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "boolean flag"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if10.json
@@ -15,7 +15,13 @@
       {
         "id": "165979",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if2.json
@@ -15,7 +15,13 @@
       {
         "id": "56766",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int price"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -15,7 +15,13 @@
       {
         "id": "69755",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "Food food"
+            ],
+            "return": "Food"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if4.json
@@ -15,7 +15,12 @@
       {
         "id": "87177",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int price"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if5.json
@@ -15,7 +15,13 @@
       {
         "id": "105498",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if6.json
@@ -15,7 +15,13 @@
       {
         "id": "115263",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if7.json
@@ -15,7 +15,13 @@
       {
         "id": "124346",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if8.json
@@ -15,7 +15,13 @@
       {
         "id": "138327",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if9.json
@@ -15,7 +15,13 @@
       {
         "id": "154199",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if_windows1.json
@@ -15,7 +15,12 @@
       {
         "id": "47311",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "boolean flag"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock3.json
@@ -15,7 +15,10 @@
       {
         "id": "48237",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock4.json
@@ -15,7 +15,10 @@
       {
         "id": "56173",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match1.json
@@ -15,7 +15,13 @@
       {
         "id": "43963",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string color"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match10.json
@@ -15,7 +15,14 @@
       {
         "id": "230366",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity",
+              "int ripeness"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match11.json
@@ -15,7 +15,13 @@
       {
         "id": "256499",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "map<anydata> data"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match12.json
@@ -15,7 +15,13 @@
       {
         "id": "272619",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "map<anydata> data"
+            ],
+            "return": "string|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match2.json
@@ -15,7 +15,13 @@
       {
         "id": "58068",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int ripeness"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match3.json
@@ -15,7 +15,13 @@
       {
         "id": "77970",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "Fruit fruit"
+            ],
+            "return": "Fruit"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match4.json
@@ -15,7 +15,13 @@
       {
         "id": "101716",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int price"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match5.json
@@ -15,7 +15,13 @@
       {
         "id": "125555",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match6.json
@@ -15,7 +15,13 @@
       {
         "id": "142202",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match7.json
@@ -15,7 +15,13 @@
       {
         "id": "156307",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match8.json
@@ -15,7 +15,13 @@
       {
         "id": "177387",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "any quantity"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match9.json
@@ -15,7 +15,14 @@
       {
         "id": "205659",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int quantity",
+              "string season"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call3.json
@@ -15,7 +15,10 @@
       {
         "id": "37077",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call_time.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/method_call_time.json
@@ -15,7 +15,10 @@
       {
         "id": "35000",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node1.json
@@ -15,7 +15,10 @@
       {
         "id": "38352",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node2.json
@@ -15,7 +15,13 @@
       {
         "id": "44924",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "boolean isKandy"
+            ],
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node4.json
@@ -15,7 +15,10 @@
       {
         "id": "61385",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/nested_node5.json
@@ -15,7 +15,10 @@
       {
         "id": "74281",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection1.json
@@ -15,7 +15,10 @@
       {
         "id": "38937",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection2.json
@@ -15,7 +15,10 @@
       {
         "id": "46873",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/new_connection4.json
@@ -15,7 +15,10 @@
       {
         "id": "39867",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get2.json
@@ -15,7 +15,10 @@
       {
         "id": "66686",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "json|http:ClientError"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-get3.json
@@ -15,7 +15,10 @@
       {
         "id": "73630",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "json|http:ClientError"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post2.json
@@ -15,7 +15,10 @@
       {
         "id": "64702",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "json|http:ClientError"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-http-post3.json
@@ -15,7 +15,10 @@
       {
         "id": "70685",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "json|http:ClientError"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-mysql1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-mysql1.json
@@ -15,7 +15,10 @@
       {
         "id": "42936",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-mysql2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/remote_action_call-mysql2.json
@@ -15,7 +15,10 @@
       {
         "id": "47586",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-get1.json
@@ -15,7 +15,10 @@
       {
         "id": "46939",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "http:ClientError?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/resource_action_call-http-post1.json
@@ -15,7 +15,10 @@
       {
         "id": "46908",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "http:ClientError?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/simple_flow.json
@@ -15,7 +15,10 @@
       {
         "id": "40305",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "json|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/stop2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/stop2.json
@@ -15,7 +15,13 @@
       {
         "id": "37139",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int x"
+            ],
+            "return": "int?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction2.json
@@ -15,7 +15,13 @@
       {
         "id": "39619",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int i"
+            ],
+            "return": "int|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction3.json
@@ -15,7 +15,10 @@
       {
         "id": "52143",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction4.json
@@ -15,7 +15,10 @@
       {
         "id": "61226",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction5.json
@@ -15,7 +15,10 @@
       {
         "id": "69162",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction6.json
@@ -15,7 +15,10 @@
       {
         "id": "77191",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction8.json
@@ -15,7 +15,13 @@
       {
         "id": "33388",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int? i"
+            ],
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/transaction9.json
@@ -15,7 +15,13 @@
       {
         "id": "43742",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int? i"
+            ],
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable5.json
@@ -15,7 +15,13 @@
       {
         "id": "60234",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int amount"
+            ],
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable6.json
@@ -15,7 +15,13 @@
       {
         "id": "64264",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int amount"
+            ],
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable7.json
@@ -15,7 +15,10 @@
       {
         "id": "70433",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait2.json
@@ -15,7 +15,10 @@
       {
         "id": "62187",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait3.json
@@ -15,7 +15,10 @@
       {
         "id": "69410",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait4.json
@@ -15,7 +15,10 @@
       {
         "id": "83422",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "string|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait5.json
@@ -15,7 +15,10 @@
       {
         "id": "107168",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "map<string|error>"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait6.json
@@ -15,7 +15,10 @@
       {
         "id": "124249",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "map<string|error>"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait7.json
@@ -15,7 +15,10 @@
       {
         "id": "164797",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "MixedResult"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait8.json
@@ -15,7 +15,13 @@
       {
         "id": "185970",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "boolean condition"
+            ],
+            "return": "error?"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/wait9.json
@@ -15,7 +15,10 @@
       {
         "id": "203950",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "return": "any"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -15,7 +15,12 @@
       {
         "id": "38445",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -15,7 +15,12 @@
       {
         "id": "57262",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -15,7 +15,12 @@
       {
         "id": "69135",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while5.json
@@ -15,7 +15,14 @@
       {
         "id": "82403",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count",
+              "int retries"
+            ],
+            "return": "string"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -15,7 +15,12 @@
       {
         "id": "104971",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -15,7 +15,12 @@
       {
         "id": "119820",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -15,7 +15,12 @@
       {
         "id": "134948",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "int count"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler1.json
@@ -21,7 +21,13 @@
       {
         "id": "38135",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string? name"
+            ],
+            "return": "string|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler2.json
@@ -21,7 +21,13 @@
       {
         "id": "38135",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string? name"
+            ],
+            "return": "string|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/error_handler3.json
@@ -21,7 +21,13 @@
       {
         "id": "38197",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "string? name"
+            ],
+            "return": "string|error"
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if1.json
@@ -21,7 +21,12 @@
       {
         "id": "32768",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "boolean flag"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if2.json
@@ -21,7 +21,12 @@
       {
         "id": "32768",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "boolean flag"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if3.json
@@ -21,7 +21,12 @@
       {
         "id": "32799",
         "metadata": {
-          "label": "Start"
+          "label": "Start",
+          "data": {
+            "parameters": [
+              "boolean flag"
+            ]
+          }
         },
         "codedata": {
           "node": "EVENT_START",


### PR DESCRIPTION
## Purpose
$title with the following change to the `Start` event node in the flow diagram.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/125

```json
{
  "id": "51465",
  "metadata": {
    "label": "Start",
    "data": {
      "parameters": [
        "string 'from",
        "string to",
        "decimal amount"
      ],
      "return": "json|http:InternalServerError"
    }
  },
  "codedata": {
    "node": "EVENT_START",
    "lineRange": {
      "fileName": "main.bal",
      "startLine": {
        "line": 15,
        "offset": 115
      },
      "endLine": {
        "line": 56,
        "offset": 5
      }
    },
  },
  "returning": false,
  "flags": 0
}
```