### PR TITLE
Remove the diagnostic output for read-only field types in the type editor

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/TypeDiagnosticRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/TypeDiagnosticRequest.java
@@ -52,7 +52,7 @@ public class TypeDiagnosticRequest extends DiagnosticsRequest {
 
     @Override
     protected Node getParsedNode(String text) {
-        return NodeParser.parseTypeDescriptor(text);
+        return NodeParser.parseTypeDescriptor(getTrimmedOutput(text));
     }
 
     @Override
@@ -64,12 +64,13 @@ public class TypeDiagnosticRequest extends DiagnosticsRequest {
             return Set.of();
         }
         Set<Diagnostic> diagnostics = new HashSet<>();
+        String inputExpression = getTrimmedOutput(context.info().expression());
 
         // Check for undefined types
         Types types = semanticModel.get().types();
-        Optional<TypeSymbol> typeSymbol = types.getType(document.get(), context.info().expression());
+        Optional<TypeSymbol> typeSymbol = types.getType(document.get(), inputExpression);
         if (typeSymbol.isEmpty()) {
-            String message = String.format(UNDEFINED_TYPE, context.info().expression());
+            String message = String.format(UNDEFINED_TYPE, inputExpression);
             diagnostics.add(CommonUtils.createDiagnostic(message, context.getExpressionLineRange(),
                     UNKNOWN_TYPE_ERROR_CODE));
             return diagnostics;
@@ -83,11 +84,23 @@ public class TypeDiagnosticRequest extends DiagnosticsRequest {
         Optional<TypeSymbol> typeConstraintTypeSymbol = types.getType(document.get(), typeConstraint);
         if (typeConstraintTypeSymbol.isPresent()) {
             if (!typeSymbol.get().subtypeOf(typeConstraintTypeSymbol.get())) {
-                String message = String.format(INVALID_SUBTYPE, typeConstraint, context.info().expression());
+                String message = String.format(INVALID_SUBTYPE, typeConstraint, inputExpression);
                 diagnostics.add(CommonUtils.createDiagnostic(message, context.getExpressionLineRange(),
                         "", DiagnosticSeverity.ERROR));
             }
         }
         return diagnostics;
+    }
+
+    private String getTrimmedOutput(String text) {
+        // TODO: The following is a temporary fix for the invalid diagnostic produced for the readonly flag in the
+        //  type descriptor. Ideally, this should be a flag in the type editor (as it is not part of the type
+        //  descriptor). Tracked with: https://github.com/wso2/product-ballerina-integrator/issues/150
+        // If the input starts with "readonly ", then obtain the string after this prefix
+        String trimmedInput = text.trim();
+        if (trimmedInput.startsWith("readonly ")) {
+            return trimmedInput.substring(9);
+        }
+        return text;
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types15.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types15.json
@@ -1,0 +1,40 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "readonly int",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 12,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Type",
+        "description": "Type of the variable"
+      },
+      "valueType": "TYPE",
+      "value": "",
+      "placeholder": "var",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types16.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types16.json
@@ -1,0 +1,40 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "readonly",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 8,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Type",
+        "description": "Type of the variable"
+      },
+      "valueType": "TYPE",
+      "value": "",
+      "placeholder": "var",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types17.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types17.json
@@ -1,0 +1,40 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": " \t readonly",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 9,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Type",
+        "description": "Type of the variable"
+      },
+      "valueType": "TYPE",
+      "value": "",
+      "placeholder": "var",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types18.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types18.json
@@ -1,0 +1,58 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "readonlystring",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 14,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Type",
+        "description": "Type of the variable"
+      },
+      "valueType": "TYPE",
+      "value": "",
+      "placeholder": "var",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 1,
+          "character": 14
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2069"
+      },
+      "message": "undefined type 'readonlystring'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types19.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/types19.json
@@ -1,0 +1,40 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": " \t readonly boolean",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 9,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Type",
+        "description": "Type of the variable"
+      },
+      "valueType": "TYPE",
+      "value": "",
+      "placeholder": "var",
+      "optional": false,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}


### PR DESCRIPTION
## Purpose
Until this is implemented as a flag, the diagnostic is removed to allow users to save such nodes

Fixes https://github.com/wso2/product-ballerina-integrator/issues/130

The proper solution is tracked with https://github.com/wso2/product-ballerina-integrator/issues/150