### PR TITLE
Fix issues in Design Model and Remove create listener with default configurations option

### DIFF
--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/CodeAnalyzer.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/CodeAnalyzer.java
@@ -241,7 +241,8 @@ public class CodeAnalyzer extends NodeVisitor {
     public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
         if (!(functionCallExpressionNode.functionName() instanceof QualifiedNameReferenceNode)) {
             if (this.currentFunctionModel != null) {
-                this.currentFunctionModel.dependentFuncs.add(functionCallExpressionNode.functionName().toSourceCode());
+                this.currentFunctionModel.dependentFuncs.add(functionCallExpressionNode.functionName()
+                        .toSourceCode().trim());
             }
             functionCallExpressionNode.arguments().forEach(arg -> arg.accept(this));
         }

--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/DesignModelGenerator.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/DesignModelGenerator.java
@@ -196,6 +196,9 @@ public class DesignModelGenerator {
             functionModel.dependentFuncs.forEach(dependentFunc -> {
                 IntermediateModel.FunctionModel dependentFunctionModel = intermediateModel.functionModelMap
                         .get(dependentFunc);
+                if (dependentFunctionModel == null) {
+                    return;
+                }
                 if (!dependentFunctionModel.analyzed) {
                     buildConnectionGraph(intermediateModel, dependentFunctionModel);
                 }

--- a/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/IntermediateModel.java
+++ b/architecture-model-generator/modules/architecture-model-generator-core/src/main/java/io/ballerina/designmodelgenerator/core/IntermediateModel.java
@@ -53,7 +53,7 @@ public class IntermediateModel {
     public static class ServiceModel {
         protected List<FunctionModel> remoteFunctions;
         protected List<FunctionModel> resourceFunctions;
-        protected List<FunctionModel> otherFunctions;
+        protected Map<String, FunctionModel> otherFunctions;
         protected Location location;
         protected String absolutePath;
         protected String displayName;
@@ -68,13 +68,14 @@ public class IntermediateModel {
             this.location = location;
             this.remoteFunctions = new ArrayList<>();
             this.resourceFunctions = new ArrayList<>();
-            this.otherFunctions = new ArrayList<>();
+            this.otherFunctions = new HashMap<>();
         }
     }
 
     public static class FunctionModel {
         protected final String name;
         protected final Set<String> dependentFuncs;
+        protected final Set<String> dependentObjFuncs = new HashSet<>();
         protected boolean analyzed;
         protected boolean visited;
         protected final Set<String> allDependentConnections;

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/project_with_private_methods.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/project_with_private_methods.json
@@ -1,0 +1,146 @@
+{
+  "description": "Project with imported listener",
+  "projectPath": "project_5",
+  "output": {
+    "designModel": {
+      "connections": [
+        {
+          "symbol": "User_API_Config",
+          "location": {
+            "filePath": "/Users/lakshanweerasinghe/Documents/repos/ballerina-platform/ballerina-dev-tools/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/main.bal",
+            "startLine": {
+              "line": 42,
+              "offset": 8
+            },
+            "endLine": {
+              "line": 42,
+              "offset": 84
+            }
+          },
+          "scope": "LOCAL",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.14.0.png",
+          "dependentFunctions": [],
+          "dependentConnection": [],
+          "uuid": "0701e68c-d33a-fbf6-f4e9-23f1f080e8c4",
+          "enableFlowModel": true,
+          "sortText": "main.bal42"
+        }
+      ],
+      "listeners": [
+        {
+          "symbol": "HTTP_Listener_Configuration",
+          "location": {
+            "filePath": "/Users/lakshanweerasinghe/Documents/repos/ballerina-platform/ballerina-dev-tools/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/main.bal",
+            "startLine": {
+              "line": 20,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 20,
+              "offset": 90
+            }
+          },
+          "attachedServices": [
+            "4b2ce25c-8e27-7432-7f07-0339a03b48aa"
+          ],
+          "kind": "NAMED",
+          "type": "http:Listener",
+          "args": [
+            {
+              "key": "port",
+              "value": "8081"
+            },
+            {
+              "key": "config",
+              "value": "{host: \"0.0.0.0\"}"
+            }
+          ],
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.14.0.png",
+          "uuid": "4aaaa860-5541-b7c0-4859-00bd0bbbd1ff",
+          "enableFlowModel": true,
+          "sortText": "main.bal20"
+        }
+      ],
+      "services": [
+        {
+          "location": {
+            "filePath": "/Users/lakshanweerasinghe/Documents/repos/ballerina-platform/ballerina-dev-tools/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/main.bal",
+            "startLine": {
+              "line": 22,
+              "offset": 0
+            },
+            "endLine": {
+              "line": 53,
+              "offset": 1
+            }
+          },
+          "attachedListeners": [
+            "4aaaa860-5541-b7c0-4859-00bd0bbbd1ff"
+          ],
+          "connections": [
+            "0701e68c-d33a-fbf6-f4e9-23f1f080e8c4"
+          ],
+          "functions": [
+            {
+              "name": "init",
+              "location": {
+                "filePath": "/Users/lakshanweerasinghe/Documents/repos/ballerina-platform/ballerina-dev-tools/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/main.bal",
+                "startLine": {
+                  "line": 25,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 27,
+                  "offset": 5
+                }
+              },
+              "connections": []
+            },
+            {
+              "name": "_invokeEndPoint0_",
+              "location": {
+                "filePath": "/Users/lakshanweerasinghe/Documents/repos/ballerina-platform/ballerina-dev-tools/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/main.bal",
+                "startLine": {
+                  "line": 34,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 52,
+                  "offset": 5
+                }
+              },
+              "connections": [
+                "0701e68c-d33a-fbf6-f4e9-23f1f080e8c4"
+              ]
+            }
+          ],
+          "remoteFunctions": [],
+          "resourceFunctions": [
+            {
+              "accessor": "get",
+              "path": "user/[string id]",
+              "location": {
+                "filePath": "/Users/lakshanweerasinghe/Documents/repos/ballerina-platform/ballerina-dev-tools/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/main.bal",
+                "startLine": {
+                  "line": 29,
+                  "offset": 4
+                },
+                "endLine": {
+                  "line": 32,
+                  "offset": 5
+                }
+              },
+              "connections": []
+            }
+          ],
+          "absolutePath": "/ ",
+          "type": "http:Service",
+          "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.14.0.png",
+          "uuid": "4b2ce25c-8e27-7432-7f07-0339a03b48aa",
+          "enableFlowModel": true,
+          "sortText": "main.bal22"
+        }
+      ]
+    }
+  }
+}

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/project_with_private_methods.json
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/config/project_with_private_methods.json
@@ -21,7 +21,7 @@
           "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.14.0.png",
           "dependentFunctions": [],
           "dependentConnection": [],
-          "uuid": "0701e68c-d33a-fbf6-f4e9-23f1f080e8c4",
+          "uuid": "3f05dd8a-b9df-6942-dadf-c4cf7dbc8bc6",
           "enableFlowModel": true,
           "sortText": "main.bal42"
         }
@@ -41,7 +41,7 @@
             }
           },
           "attachedServices": [
-            "4b2ce25c-8e27-7432-7f07-0339a03b48aa"
+            "f7f0bcba-a81a-5123-445c-44a5e3919000"
           ],
           "kind": "NAMED",
           "type": "http:Listener",
@@ -56,7 +56,7 @@
             }
           ],
           "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.14.0.png",
-          "uuid": "4aaaa860-5541-b7c0-4859-00bd0bbbd1ff",
+          "uuid": "a1c623a0-2066-70c9-7368-978d7f083631",
           "enableFlowModel": true,
           "sortText": "main.bal20"
         }
@@ -75,10 +75,10 @@
             }
           },
           "attachedListeners": [
-            "4aaaa860-5541-b7c0-4859-00bd0bbbd1ff"
+            "a1c623a0-2066-70c9-7368-978d7f083631"
           ],
           "connections": [
-            "0701e68c-d33a-fbf6-f4e9-23f1f080e8c4"
+            "3f05dd8a-b9df-6942-dadf-c4cf7dbc8bc6"
           ],
           "functions": [
             {
@@ -110,7 +110,7 @@
                 }
               },
               "connections": [
-                "0701e68c-d33a-fbf6-f4e9-23f1f080e8c4"
+                "3f05dd8a-b9df-6942-dadf-c4cf7dbc8bc6"
               ]
             }
           ],
@@ -130,13 +130,15 @@
                   "offset": 5
                 }
               },
-              "connections": []
+              "connections": [
+                "3f05dd8a-b9df-6942-dadf-c4cf7dbc8bc6"
+              ]
             }
           ],
           "absolutePath": "/ ",
           "type": "http:Service",
           "icon": "https://bcentral-packageicons.azureedge.net/images/ballerina_http_2.14.0.png",
-          "uuid": "4b2ce25c-8e27-7432-7f07-0339a03b48aa",
+          "uuid": "f7f0bcba-a81a-5123-445c-44a5e3919000",
           "enableFlowModel": true,
           "sortText": "main.bal22"
         }

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "wso2"
+name = "imported_listener"
+version = "0.1.0"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/main.bal
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/get_design_model/source/project_5/main.bal
@@ -1,0 +1,76 @@
+import ballerina/http;
+
+public type FlowVars record {|
+    string userId?;
+|};
+
+public type InboundProperties record {|
+    http:Response response;
+    map<string> uriParams;
+|};
+
+public type Context record {|
+    anydata payload;
+    FlowVars flowVars;
+    InboundProperties inboundProperties;
+|};
+
+public type Record record {
+};
+
+public listener http:Listener HTTP_Listener_Configuration = new (8081, {host: "0.0.0.0"});
+
+service / on HTTP_Listener_Configuration {
+    Context ctx;
+
+    function init() {
+        self.ctx = {payload: (), flowVars: {}, inboundProperties: {response: new, uriParams: {}}};
+    }
+
+    resource function get user/[string id]() returns http:Response|error {
+        self.ctx.inboundProperties.uriParams = {id};
+        return self._invokeEndPoint0_(self.ctx);
+    }
+
+    private function _invokeEndPoint0_(Context ctx) returns http:Response|error {
+        ctx.flowVars.userId = ctx.inboundProperties.uriParams["userId"];
+
+        if ctx.flowVars.userId == null {
+            ctx.flowVars.userId = "1";
+        }
+
+        // http client request
+        http:Client User_API_Config = check new ("jsonplaceholder.typicode.com:80");
+        http:Response _clientResult0_ = check User_API_Config->/users/\#\[flowVars\.userId\].get();
+        ctx.payload = check _clientResult0_.getJsonPayload();
+
+        processUserDataSubflow(ctx);
+
+        // async operation
+        _ = start _async0_(ctx);
+        ctx.inboundProperties.response.setPayload("");
+        return ctx.inboundProperties.response;
+    }
+}
+
+public function _vmReceive0_(Context ctx) {
+}
+
+public function _async0_(Context ctx) {
+    worker W returns error? {
+        // VM Inbound Endpoint
+        anydata receivedPayload = check <- function;
+        ctx.payload = receivedPayload;
+        _vmReceive0_(ctx);
+    }
+
+    // VM Outbound Endpoint
+    ctx.payload -> W;
+}
+
+public function processUserDataSubflow(Context ctx) {
+    // set payload
+    string _payload0_ = "Final processed ctx.payload with user info and roles: " + ctx.payload.toString();
+    ctx.payload = _payload0_;
+    ctx.inboundProperties.response.setPayload(_payload0_);
+}

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/ServiceModelGeneratorConstants.java
@@ -72,6 +72,7 @@ public class ServiceModelGeneratorConstants {
     public static final String KIND_DEFAULT = "DEFAULT";
     public static final String KIND_REQUIRED = "REQUIRED";
     public static final String KIND_DEFAULTABLE = "DEFAULTABLE";
+    public static final String KIND_OBJECT_METHOD = "OBJECT_METHOD";
 
     public static final String PARAMETER = "parameter";
     public static final String SERVICE = "service";

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Function.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/model/Function.java
@@ -32,7 +32,7 @@ import static io.ballerina.servicemodelgenerator.extension.ServiceModelGenerator
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.FIELD_TYPE_METADATA;
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.FUNCTION_NAME_METADATA;
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.FUNCTION_RETURN_TYPE_METADATA;
-import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.KIND_DEFAULT;
+import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.KIND_OBJECT_METHOD;
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.RESOURCE_FUNCTION_RETURN_TYPE_METADATA;
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.RESOURCE_NAME_METADATA;
 import static io.ballerina.servicemodelgenerator.extension.util.ServiceClassUtil.ServiceClassContext.GRAPHQL_DIAGRAM;
@@ -83,7 +83,7 @@ public class Function {
                 .metadata("", "")
                 .accessor(functionAccessor())
                 .parameters(new ArrayList<>())
-                .kind(KIND_DEFAULT)
+                .kind(KIND_OBJECT_METHOD)
                 .enabled(true);
         if (context == GRAPHQL_DIAGRAM) {
             functionBuilder

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/HttpUtil.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/HttpUtil.java
@@ -60,6 +60,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.KIND_RESOURCE;
 import static io.ballerina.servicemodelgenerator.extension.util.Utils.getFunctionModel;
 import static io.ballerina.servicemodelgenerator.extension.util.Utils.getPath;
 import static io.ballerina.servicemodelgenerator.extension.util.Utils.populateListenerInfo;
@@ -268,7 +269,7 @@ public final class HttpUtil {
 
         // functions contains in source but not enforced using the service contract type
         commonSvcModel.getFunctions().forEach(functionModel -> {
-            if (functionModel.getKind().equals(ServiceModelGeneratorConstants.KIND_RESOURCE)) {
+            if (functionModel.getKind().equals(KIND_RESOURCE)) {
                 getResourceFunctionModel().ifPresentOrElse(
                         resourceFunction -> {
                             // remove the default json response from the resource function
@@ -281,6 +282,8 @@ public final class HttpUtil {
                         () -> serviceModel.addFunction(functionModel)
                 );
             } else {
+                functionModel.setAnnotations(null);
+                functionModel.getAccessor().setEnabled(false);
                 serviceModel.addFunction(functionModel);
             }
         });

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerUtil.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/ListenerUtil.java
@@ -152,7 +152,7 @@ public class ListenerUtil {
             listeners.add(HTTP_DEFAULT_LISTENER_ITEM_LABEL);
         }
 
-        if (!isHttp && !moduleName.equals("ai") && listeners.isEmpty()) {
+        if (moduleName.equals("graphql")) {
             listeners.add(DEFAULT_LISTENER_ITEM_LABEL.formatted(moduleName(moduleName)));
         }
 

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/Utils.java
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/main/java/io/ballerina/servicemodelgenerator/extension/util/Utils.java
@@ -85,6 +85,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.GET;
+import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.KIND_DEFAULT;
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.KIND_DEFAULTABLE;
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.KIND_MUTATION;
 import static io.ballerina.servicemodelgenerator.extension.ServiceModelGeneratorConstants.KIND_QUERY;
@@ -275,6 +276,10 @@ public final class Utils {
 
         Function functionModel = Function.getNewFunctionModel(context);
         functionModel.setAnnotations(annotations);
+
+        if (isInit) {
+            functionModel.setKind(KIND_DEFAULT);
+        }
 
         Value functionName = functionModel.getName();
         functionName.setValue(functionDefinitionNode.functionName().text().trim());

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/kafka_service_model_2.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/kafka_service_model_2.json
@@ -37,9 +37,7 @@
           "placeholder": "",
           "optional": false,
           "advanced": false,
-          "items": [
-            "(+) Create and use a kafka listener with default configurations"
-          ],
+          "items": [],
           "codedata": {
             "inListenerInit": false,
             "isBasePath": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/rabbitmq_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/rabbitmq_service_model.json
@@ -37,9 +37,7 @@
           "placeholder": "",
           "optional": false,
           "advanced": false,
-          "items": [
-            "(+) Create and use a rabbitmq listener with default configurations"
-          ],
+          "items": [],
           "codedata": {
             "inListenerInit": false,
             "isBasePath": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/tcp_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_service_model/config/tcp_service_model.json
@@ -37,9 +37,7 @@
           "placeholder": "",
           "optional": false,
           "advanced": false,
-          "items": [
-            "(+) Create and use a tcp listener with default configurations"
-          ],
+          "items": [],
           "codedata": {
             "inListenerInit": false,
             "isBasePath": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/graphql_service_with_single_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/graphql_service_with_single_listener.json
@@ -42,7 +42,8 @@
         "optional": false,
         "advanced": false,
         "items": [
-          "graphQLListener"
+          "graphQLListener",
+          "(+) Create and use a graphql listener with default configurations"
         ],
         "codedata": {
           "inListenerInit": false,

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_anonymous_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_anonymous_listener.json
@@ -136,7 +136,7 @@
             "label": "Accessor",
             "description": "The accessor of the function"
           },
-          "enabled": true,
+          "enabled": false,
           "editable": true,
           "valueType": "IDENTIFIER",
           "isType": false,
@@ -195,41 +195,6 @@
           "inListenerInit": false,
           "isBasePath": false,
           "inDisplayAnnotation": false
-        },
-        "annotations": {
-          "annotResourceConfig": {
-            "metadata": {
-              "label": "Resource Configuration",
-              "description": "Define advanced configurations like resource level media types, security, etc."
-            },
-            "enabled": true,
-            "editable": true,
-            "valueType": "EXPRESSION",
-            "valueTypeConstraint": "http:HttpResourceConfig",
-            "isType": false,
-            "placeholder": "{}",
-            "optional": true,
-            "advanced": true,
-            "codedata": {
-              "inListenerInit": false,
-              "isBasePath": false,
-              "inDisplayAnnotation": false,
-              "type": "ANNOTATION_ATTACHMENT",
-              "originalName": "ResourceConfig",
-              "orgName": "ballerina",
-              "moduleName": "http"
-            },
-            "addNewButton": false,
-            "typeMembers": [
-              {
-                "type": "HttpResourceConfig",
-                "packageInfo": "ballerina:http:2.14.0",
-                "kind": "RECORD_TYPE",
-                "selected": false
-              }
-            ],
-            "imports": {}
-          }
         }
       },
       {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_global_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_global_listener.json
@@ -144,7 +144,7 @@
             "label": "Accessor",
             "description": "The accessor of the function"
           },
-          "enabled": true,
+          "enabled": false,
           "editable": true,
           "valueType": "IDENTIFIER",
           "isType": false,
@@ -203,41 +203,6 @@
           "inListenerInit": false,
           "isBasePath": false,
           "inDisplayAnnotation": false
-        },
-        "annotations": {
-          "annotResourceConfig": {
-            "metadata": {
-              "label": "Resource Configuration",
-              "description": "Define advanced configurations like resource level media types, security, etc."
-            },
-            "enabled": true,
-            "editable": true,
-            "valueType": "EXPRESSION",
-            "valueTypeConstraint": "http:HttpResourceConfig",
-            "isType": false,
-            "placeholder": "{}",
-            "optional": true,
-            "advanced": true,
-            "codedata": {
-              "inListenerInit": false,
-              "isBasePath": false,
-              "inDisplayAnnotation": false,
-              "type": "ANNOTATION_ATTACHMENT",
-              "originalName": "ResourceConfig",
-              "orgName": "ballerina",
-              "moduleName": "http"
-            },
-            "addNewButton": false,
-            "typeMembers": [
-              {
-                "type": "HttpResourceConfig",
-                "packageInfo": "ballerina:http:2.14.0",
-                "kind": "RECORD_TYPE",
-                "selected": false
-              }
-            ],
-            "imports": {}
-          }
         }
       },
       {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_single_listener.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/http_service_with_single_listener.json
@@ -6,7 +6,7 @@
     "offset": 0
   },
   "end": {
-    "line": 25,
+    "line": 28,
     "offset": 0
   },
   "response": {
@@ -117,7 +117,7 @@
           "offset": 0
         },
         "endLine": {
-          "line": 25,
+          "line": 28,
           "offset": 1
         }
       },
@@ -137,7 +137,7 @@
             "label": "Accessor",
             "description": "The accessor of the function"
           },
-          "enabled": true,
+          "enabled": false,
           "editable": true,
           "valueType": "IDENTIFIER",
           "isType": false,
@@ -196,42 +196,6 @@
           "inListenerInit": false,
           "isBasePath": false,
           "inDisplayAnnotation": false
-        },
-        "annotations": {
-          "annotResourceConfig": {
-            "metadata": {
-              "label": "Resource Configuration",
-              "description": "Define advanced configurations like resource level media types, security, etc."
-            },
-            "enabled": true,
-            "editable": true,
-            "value": "{\n        consumes: []\n    }",
-            "valueType": "EXPRESSION",
-            "valueTypeConstraint": "http:HttpResourceConfig",
-            "isType": false,
-            "placeholder": "{}",
-            "optional": true,
-            "advanced": true,
-            "codedata": {
-              "inListenerInit": false,
-              "isBasePath": false,
-              "inDisplayAnnotation": false,
-              "type": "ANNOTATION_ATTACHMENT",
-              "originalName": "ResourceConfig",
-              "orgName": "ballerina",
-              "moduleName": "http"
-            },
-            "addNewButton": false,
-            "typeMembers": [
-              {
-                "type": "HttpResourceConfig",
-                "packageInfo": "ballerina:http:2.14.0",
-                "kind": "RECORD_TYPE",
-                "selected": false
-              }
-            ],
-            "imports": {}
-          }
         }
       },
       {
@@ -1050,6 +1014,127 @@
             ],
             "imports": {}
           }
+        }
+      },
+      {
+        "metadata": {
+          "label": "",
+          "description": ""
+        },
+        "kind": "OBJECT_METHOD",
+        "accessor": {
+          "metadata": {
+            "label": "Accessor",
+            "description": "The accessor of the function"
+          },
+          "enabled": false,
+          "editable": true,
+          "valueType": "IDENTIFIER",
+          "isType": false,
+          "optional": false,
+          "advanced": false,
+          "addNewButton": false,
+          "imports": {}
+        },
+        "name": {
+          "metadata": {
+            "label": "Function Name",
+            "description": "The name of the function"
+          },
+          "enabled": true,
+          "editable": true,
+          "value": "foo",
+          "valueType": "IDENTIFIER",
+          "isType": false,
+          "optional": false,
+          "advanced": false,
+          "addNewButton": false,
+          "imports": {}
+        },
+        "parameters": [],
+        "schema": {
+          "parameter": {
+            "type": {
+              "metadata": {
+                "label": "Parameter Type",
+                "description": "The type of the parameter"
+              },
+              "enabled": true,
+              "editable": true,
+              "valueType": "TYPE",
+              "isType": true,
+              "optional": false,
+              "advanced": false,
+              "addNewButton": false,
+              "imports": {}
+            },
+            "name": {
+              "metadata": {
+                "label": "Parameter Name",
+                "description": "The name of the parameter"
+              },
+              "enabled": true,
+              "editable": true,
+              "valueType": "IDENTIFIER",
+              "isType": false,
+              "optional": false,
+              "advanced": false,
+              "addNewButton": false,
+              "imports": {}
+            },
+            "defaultValue": {
+              "metadata": {
+                "label": "Default Value",
+                "description": "The default value of the parameter"
+              },
+              "enabled": true,
+              "editable": true,
+              "valueType": "EXPRESSION",
+              "isType": false,
+              "optional": true,
+              "advanced": false,
+              "addNewButton": false,
+              "imports": {}
+            },
+            "enabled": true,
+            "editable": true,
+            "optional": false,
+            "advanced": false
+          }
+        },
+        "returnType": {
+          "hasError": false,
+          "metadata": {
+            "label": "Return Type",
+            "description": "The return type of the function"
+          },
+          "enabled": true,
+          "editable": true,
+          "valueType": "TYPE",
+          "isType": false,
+          "optional": true,
+          "advanced": false,
+          "addNewButton": false
+        },
+        "enabled": true,
+        "optional": false,
+        "editable": true,
+        "canAddParameters": true,
+        "codedata": {
+          "lineRange": {
+            "fileName": "main.bal",
+            "startLine": {
+              "line": 26,
+              "offset": 4
+            },
+            "endLine": {
+              "line": 27,
+              "offset": 5
+            }
+          },
+          "inListenerInit": false,
+          "isBasePath": false,
+          "inDisplayAnnotation": false
         }
       }
     ]

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/kafka_service_model.json
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/config/kafka_service_model.json
@@ -42,7 +42,6 @@
         "optional": false,
         "advanced": false,
         "items": [
-          "(+) Create and use a kafka listener with default configurations",
           "kafkaListener"
         ],
         "codedata": {

--- a/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/source/sample1/main.bal
+++ b/service-model-generator/modules/service-model-generator-ls-extension/src/test/resources/get_sm_from_source/source/sample1/main.bal
@@ -23,6 +23,9 @@ service /api/test on httpListener {
             // handle error
         }
     }
+
+    private function foo() {
+    }
 }
 
 public type OkResponse record {|


### PR DESCRIPTION
## Purpose
$subject

This PR will fix following things
- Remove create and use listener with default configurations from all service types except graphql
- Introduce a new function kind named `OBJECT_METHOD` to render methods in a service
- Fix a issue with handling NPE in design model
- Fix connection graph not drawing for nested method calls

<img width="1089" alt="Screenshot 2025-04-09 at 07 23 05" src="https://github.com/user-attachments/assets/7f6e5ab0-535a-401c-a616-e3dda660d39b" />
