### PR TITLE
Support LV expressions in forms

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/CodeAnalyzer.java
@@ -404,7 +404,7 @@ class CodeAnalyzer extends NodeVisitor {
                     throw new IllegalStateException("SystemPrompt argument not found for the new expression: " +
                             newExpressionNode);
                 }
-                
+
                 if (toolsArg.kind() == SyntaxKind.LIST_CONSTRUCTOR) {
                     List<ToolData> toolsData = new ArrayList<>();
                     ListConstructorExpressionNode listCtrExprNode = (ListConstructorExpressionNode) toolsArg;
@@ -1216,9 +1216,8 @@ class CodeAnalyzer extends NodeVisitor {
             return;
         }
         switch (name) {
-            case OPEN_AI_MODEL ->
-                    setAIModelType(OPEN_AI_MODEL_TYPES, OPEN_AI_MODEL_DESC, "ai:OPEN_AI_MODEL_NAMES",
-                            "\"gpt-3.5-turbo-16k-0613\"");
+            case OPEN_AI_MODEL -> setAIModelType(OPEN_AI_MODEL_TYPES, OPEN_AI_MODEL_DESC, "ai:OPEN_AI_MODEL_NAMES",
+                    "\"gpt-3.5-turbo-16k-0613\"");
             case ANTHROPIC_MODEL ->
                     setAIModelType(ANTHROPIC_MODEL_TYPES, ANTHROPIC_MODEL_DESC, "ai:ANTHROPIC_MODEL_NAMES",
                             "\"claude-3-haiku-20240307\"");
@@ -1391,13 +1390,18 @@ class CodeAnalyzer extends NodeVisitor {
                     .description(AssignBuilder.DESCRIPTION)
                     .stepOut()
                     .properties()
-                    .expression(expression, AssignBuilder.EXPRESSION_DOC, false)
-                    .data(assignmentStatementNode.varRef(), true, new HashSet<>(), true);
-        }
+                    .expression(expression, AssignBuilder.EXPRESSION_DOC, false);
 
-        if (nodeBuilder instanceof XmlPayloadBuilder || nodeBuilder instanceof JsonPayloadBuilder
-                || nodeBuilder instanceof BinaryBuilder) {
-            nodeBuilder.properties().data(assignmentStatementNode.varRef(), false, new HashSet<>(), true);
+            nodeBuilder.properties().custom()
+                    .metadata()
+                        .label(AssignBuilder.VARIABLE_LABEL)
+                        .description(AssignBuilder.VARIABLE_DOC)
+                        .stepOut()
+                    .type(Property.ValueType.LV_EXPRESSION)
+                    .value(CommonUtils.getVariableName(assignmentStatementNode.varRef()))
+                    .editable()
+                    .stepOut()
+                    .addProperty(Property.VARIABLE_KEY);
         }
         endNode(assignmentStatementNode);
     }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/DiagnosticsRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/DiagnosticsRequest.java
@@ -51,6 +51,7 @@ public abstract class DiagnosticsRequest extends DebouncedExpressionEditorReques
 
         return switch (Property.ValueType.valueOf(property.valueType())) {
             case EXPRESSION -> new ExpressionDiagnosticsRequest(context);
+            case LV_EXPRESSION -> new LvExpressionDiagnosticRequest(context);
             case IDENTIFIER -> new IdentifierDiagnosticsRequest(context);
             case TYPE -> new TypeDiagnosticRequest(context);
             default -> throw new IllegalArgumentException("Unsupported property type: " + property.valueType());
@@ -73,7 +74,7 @@ public abstract class DiagnosticsRequest extends DebouncedExpressionEditorReques
      */
     protected abstract Set<Diagnostic> getSemanticDiagnostics(ExpressionEditorContext context);
 
-    private Set<Diagnostic> getSyntaxDiagnostics(ExpressionEditorContext context) {
+    protected Set<Diagnostic> getSyntaxDiagnostics(ExpressionEditorContext context) {
         Node parsedNode = getParsedNode(context.info().expression());
         return StreamSupport.stream(parsedNode.diagnostics().spliterator(), true)
                 .map(CommonUtils::transformBallerinaDiagnostic)

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/LvExpressionDiagnosticRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/LvExpressionDiagnosticRequest.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com)
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.flowmodelgenerator.core.expressioneditor.services;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.BracedExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.IndexedExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeParser;
+import io.ballerina.flowmodelgenerator.core.expressioneditor.ExpressionEditorContext;
+import io.ballerina.modelgenerator.commons.CommonUtils;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import io.ballerina.tools.text.LineRange;
+import org.ballerinalang.langserver.common.utils.PositionUtil;
+import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Handles diagnostic requests for lv expressions validation in the expression editor.
+ *
+ * @see DiagnosticsRequest
+ * @since 2.0.0
+ */
+public class LvExpressionDiagnosticRequest extends DiagnosticsRequest {
+
+    private static final String INVALID_LHS = "Invalid expression for a variable reference '%s'";
+    private static final DiagnosticErrorCode INVALID_EXPRESSION_CODE = DiagnosticErrorCode.INVALID_EXPR_STATEMENT;
+
+    public LvExpressionDiagnosticRequest(ExpressionEditorContext context) {
+        super(context);
+    }
+
+    @Override
+    protected Node getParsedNode(String text) {
+        return NodeParser.parseExpression(text);
+    }
+
+    @Override
+    protected Set<Diagnostic> getSyntaxDiagnostics(ExpressionEditorContext context) {
+        Node parsedNode = getParsedNode(context.info().expression());
+        if (parsedNode.hasDiagnostics()) {
+            return StreamSupport.stream(parsedNode.diagnostics().spliterator(), true)
+                    .map(CommonUtils::transformBallerinaDiagnostic)
+                    .collect(Collectors.toSet());
+        }
+        if (isValidLVExpr((ExpressionNode) parsedNode)) {
+            return Set.of();
+        } else {
+            String message = String.format(INVALID_LHS, context.info().expression());
+            return Set.of(
+                    CommonUtils.createDiagnostic(message, context.getExpressionLineRange(), INVALID_EXPRESSION_CODE));
+        }
+    }
+
+    private boolean isValidLVExpr(ExpressionNode expression) {
+        return switch (expression.kind()) {
+            case SIMPLE_NAME_REFERENCE,
+                 QUALIFIED_NAME_REFERENCE,
+                 LIST_BINDING_PATTERN,
+                 MAPPING_BINDING_PATTERN,
+                 ERROR_BINDING_PATTERN,
+                 WILDCARD_BINDING_PATTERN -> true;
+            case FIELD_ACCESS -> isValidLVMemberExpr(((FieldAccessExpressionNode) expression).expression());
+            case INDEXED_EXPRESSION -> isValidLVMemberExpr(((IndexedExpressionNode) expression).containerExpression());
+            default -> expression.isMissing();
+        };
+    }
+
+    private boolean isValidLVMemberExpr(ExpressionNode expression) {
+        return switch (expression.kind()) {
+            case SIMPLE_NAME_REFERENCE,
+                 QUALIFIED_NAME_REFERENCE -> true;
+            case FIELD_ACCESS -> isValidLVMemberExpr(((FieldAccessExpressionNode) expression).expression());
+            case INDEXED_EXPRESSION -> isValidLVMemberExpr(((IndexedExpressionNode) expression).containerExpression());
+            case BRACED_EXPRESSION -> isValidLVMemberExpr(((BracedExpressionNode) expression).expression());
+            default -> expression.isMissing();
+        };
+    }
+
+    @Override
+    protected Set<Diagnostic> getSemanticDiagnostics(ExpressionEditorContext context) {
+        LineRange lineRange = context.generateStatement();
+        Optional<SemanticModel> semanticModel =
+                context.workspaceManager().semanticModel(context.filePath());
+        return semanticModel.map(model -> model.diagnostics().stream()
+                .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR &&
+                        PositionUtil.isWithinLineRange(diagnostic.location().lineRange(), lineRange))
+                .map(CommonUtils::transformBallerinaDiagnostic)
+                .collect(Collectors.toSet())).orElseGet(Set::of);
+    }
+}

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/Property.java
@@ -226,6 +226,7 @@ public record Property(Metadata metadata, String valueType, Object valueTypeCons
 
     public enum ValueType {
         EXPRESSION,
+        LV_EXPRESSION,
         IDENTIFIER,
         STRING,
         TYPE,

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AssignBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AssignBuilder.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.flowmodelgenerator.core.model.node;
 
-import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
@@ -42,8 +41,8 @@ public class AssignBuilder extends NodeBuilder {
     public static final String DESCRIPTION = "Assign a value to a variable";
     public static final String EXPRESSION_DOC = "Assign value";
 
-    public static String VARIABLE_LABEL = "Variable";
-    public static String VARIABLE_DOC = "Name of the variable/field";
+    public static final String VARIABLE_LABEL = "Variable";
+    public static final String VARIABLE_DOC = "Name of the variable/field";
 
     @Override
     public void setConcreteConstData() {

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AssignBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AssignBuilder.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.flowmodelgenerator.core.model.node;
 
+import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
@@ -40,6 +41,9 @@ public class AssignBuilder extends NodeBuilder {
     public static final String LABEL = "Assign";
     public static final String DESCRIPTION = "Assign a value to a variable";
     public static final String EXPRESSION_DOC = "Assign value";
+
+    public static String VARIABLE_LABEL = "Variable";
+    public static String VARIABLE_DOC = "Name of the variable/field";
 
     @Override
     public void setConcreteConstData() {
@@ -70,8 +74,15 @@ public class AssignBuilder extends NodeBuilder {
 
     @Override
     public void setConcreteTemplateData(TemplateContext context) {
-        properties()
-                .data(null, true, context.getAllVisibleSymbolNames())
-                .expression("", EXPRESSION_DOC);
+        properties().custom()
+                .metadata()
+                    .label(VARIABLE_LABEL)
+                    .description(VARIABLE_DOC)
+                    .stepOut()
+                .type(Property.ValueType.LV_EXPRESSION)
+                .editable()
+                .stepOut()
+                .addProperty(Property.VARIABLE_KEY);
+        properties().expression("", EXPRESSION_DOC);
     }
 }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorDiagnosticsTest.java
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/java/io/ballerina/flowmodelgenerator/extension/ExpressionEditorDiagnosticsTest.java
@@ -65,6 +65,14 @@ public class ExpressionEditorDiagnosticsTest extends AbstractLSTest {
         }
     }
 
+    @Override
+    protected String[] skipList() {
+        // TODO: Provide diagnostics when assigning a value to type
+        return new String[] {
+                "assign2.json"
+        };
+    }
+
     @Test
     public void testMultipleRequests() throws IOException, InterruptedException {
         // Load the template test config

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj10.json
@@ -1,0 +1,83 @@
+{
+  "description": "",
+  "filePath": "assign.bal",
+  "context": {
+    "expression": "s",
+    "startLine": {
+      "line": 13,
+      "offset": 0
+    },
+    "offset": 1,
+    "codedata": {
+      "node": "ASSIGN",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "completionContext": {
+    "triggerKind": "Invoked"
+  },
+  "completions": [
+    {
+      "label": "i",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "AB",
+      "insertText": "i",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "rec",
+      "kind": "Variable",
+      "detail": "MyRecord",
+      "sortText": "AB",
+      "insertText": "rec",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "strucrturedRec",
+      "kind": "Variable",
+      "detail": "MyRecord",
+      "sortText": "AB",
+      "insertText": "strucrturedRec",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "structuredArray",
+      "kind": "Variable",
+      "detail": "int[]",
+      "sortText": "AB",
+      "insertText": "structuredArray",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "structuredMap",
+      "kind": "Variable",
+      "detail": "map<string>",
+      "sortText": "AB",
+      "insertText": "structuredMap",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj11.json
@@ -1,0 +1,59 @@
+{
+  "description": "",
+  "filePath": "assign.bal",
+  "context": {
+    "expression": "rec.",
+    "startLine": {
+      "line": 13,
+      "offset": 0
+    },
+    "offset": 4,
+    "codedata": {
+      "node": "ASSIGN",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "completionContext": {
+    "triggerKind": "Invoked"
+  },
+  "completions": [
+    {
+      "label": "id",
+      "kind": "Field",
+      "detail": "string",
+      "sortText": "AA",
+      "insertText": "id",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "value",
+      "kind": "Field",
+      "detail": "int",
+      "sortText": "AA",
+      "insertText": "value",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/config/proj12.json
@@ -1,0 +1,83 @@
+{
+  "description": "",
+  "filePath": "assign.bal",
+  "context": {
+    "expression": "structuredArray[",
+    "startLine": {
+      "line": 13,
+      "offset": 0
+    },
+    "offset": 16,
+    "codedata": {
+      "node": "ASSIGN",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "completionContext": {
+    "triggerKind": "Invoked"
+  },
+  "completions": [
+    {
+      "label": "i",
+      "kind": "Variable",
+      "detail": "int",
+      "sortText": "B",
+      "insertText": "i",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "rec",
+      "kind": "Variable",
+      "detail": "MyRecord",
+      "sortText": "B",
+      "insertText": "rec",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "strucrturedRec",
+      "kind": "Variable",
+      "detail": "MyRecord",
+      "sortText": "B",
+      "insertText": "strucrturedRec",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "structuredArray",
+      "kind": "Variable",
+      "detail": "int[]",
+      "sortText": "B",
+      "insertText": "structuredArray",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "structuredMap",
+      "kind": "Variable",
+      "detail": "map<string>",
+      "sortText": "B",
+      "insertText": "structuredMap",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/source/assign.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/completions/source/assign.bal
@@ -1,0 +1,15 @@
+type MyRecord record {|
+    string id;
+    int value;
+|};
+
+MyRecord rec = {id: "1", value: 10};
+MyRecord strucrturedRec = {id: "1", value: 10};
+
+map<string> structuredMap = {"key": "value"};
+int[] structuredArray = [1, 2, 3];
+
+function fn() {
+    int i = 0;
+    
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign1.json
@@ -1,0 +1,39 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "port",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign2.json
@@ -1,0 +1,39 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "MyRecord",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign3.json
@@ -1,0 +1,39 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "rec.id",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign4.json
@@ -1,0 +1,57 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "rec.i",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 25
+        },
+        "end": {
+          "line": 1,
+          "character": 30
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2119"
+      },
+      "message": "undeclared field 'i' in record 'MyRecord'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign5.json
@@ -1,0 +1,57 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "mapVar[key]",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 32
+        },
+        "end": {
+          "line": 1,
+          "character": 35
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2010"
+      },
+      "message": "undefined symbol 'key'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign6.json
@@ -1,0 +1,39 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "mapVar[\"key\"]",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign7.json
@@ -1,0 +1,57 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "rec[\"key\"]",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 25
+        },
+        "end": {
+          "line": 1,
+          "character": 35
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE2024"
+      },
+      "message": "undefined field 'key' in 'MyRecord'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign8.json
@@ -1,0 +1,57 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "fn(rec)",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 1,
+          "character": 7
+        }
+      },
+      "severity": "Error",
+      "code": {
+        "left": "BCE3038"
+      },
+      "message": "Invalid expression for a variable reference 'fn(rec)'"
+    }
+  ]
+}

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/source/source.bal
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/source/source.bal
@@ -40,3 +40,6 @@ enum MyEnum {
     EN_A,
     EN_B
 }
+
+MyRecord rec = { id: 1 };
+map<string> mapVar = { "key": "value" };

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign1.json
@@ -149,10 +149,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "i",
             "optional": false,
             "editable": true,
@@ -199,10 +199,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "_",
             "optional": false,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign2.json
@@ -149,10 +149,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "str1",
             "optional": false,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign3.json
@@ -149,10 +149,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "j1",
             "optional": false,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign4.json
@@ -149,10 +149,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "x1",
             "optional": false,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/assign5.json
@@ -155,10 +155,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "newData1",
             "optional": false,
             "editable": true,
@@ -282,10 +282,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "newData2",
             "optional": false,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment10.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment10.json
@@ -235,10 +235,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "x",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment6.json
@@ -273,10 +273,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "x",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/comment7.json
@@ -120,10 +120,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "_",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics1.json
@@ -1077,24 +1077,15 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "c",
             "optional": false,
             "editable": true,
             "advanced": false,
-            "hidden": false,
-            "diagnostics": {
-              "hasDiagnostics": true,
-              "diagnostics": [
-                {
-                  "severity": "ERROR",
-                  "message": "cannot assign a value to function argument 'c'"
-                }
-              ]
-            }
+            "hidden": false
           }
         },
         "diagnostics": {

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/diagnostics2.json
@@ -208,10 +208,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "f",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler1.json
@@ -363,10 +363,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "msg",
                     "optional": false,
                     "editable": true,
@@ -435,10 +435,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "msg",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/error_handler2.json
@@ -363,10 +363,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "msg",
                     "optional": false,
                     "editable": true,
@@ -435,10 +435,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "msg",
                     "optional": false,
                     "editable": true,
@@ -756,10 +756,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,
@@ -828,10 +828,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach1.json
@@ -192,10 +192,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "_",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach2.json
@@ -192,10 +192,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "_",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach3.json
@@ -195,10 +195,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "_",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach4.json
@@ -195,10 +195,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "_",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/foreach5.json
@@ -195,10 +195,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "_",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/if3.json
@@ -136,10 +136,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "food.comment",
                     "optional": false,
                     "editable": true,
@@ -319,10 +319,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "food.comment",
                             "optional": false,
                             "editable": true,
@@ -391,10 +391,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "food.comment",
                             "optional": false,
                             "editable": true,
@@ -544,10 +544,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "food.comment",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/json_payload1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/json_payload1.json
@@ -126,10 +126,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "j1",
             "optional": false,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/lock2.json
@@ -235,10 +235,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "i",
                             "optional": false,
                             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/match3.json
@@ -160,10 +160,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "fruit.quality",
                     "optional": false,
                     "editable": true,
@@ -353,10 +353,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "fruit.quality",
                             "optional": false,
                             "editable": true,
@@ -452,10 +452,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "fruit.quality",
                             "optional": false,
                             "editable": true,
@@ -631,10 +631,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "fruit.quality",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/variable7.json
@@ -383,10 +383,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "a",
             "optional": false,
             "editable": true,
@@ -433,10 +433,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "s",
             "optional": false,
             "editable": true,
@@ -483,10 +483,10 @@
           },
           "variable": {
             "metadata": {
-              "label": "Name",
-              "description": "Name of the variable"
+              "label": "Variable",
+              "description": "Name of the variable/field"
             },
-            "valueType": "IDENTIFIER",
+            "valueType": "LV_EXPRESSION",
             "value": "j",
             "optional": false,
             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while1.json
@@ -491,10 +491,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,
@@ -563,10 +563,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,
@@ -618,10 +618,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "i",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while3.json
@@ -445,10 +445,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "msg",
                     "optional": false,
                     "editable": true,
@@ -555,10 +555,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "msg",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while4.json
@@ -445,10 +445,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "msg",
                     "optional": false,
                     "editable": true,
@@ -595,10 +595,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "msg",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while6.json
@@ -491,10 +491,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,
@@ -563,10 +563,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while7.json
@@ -491,10 +491,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,
@@ -563,10 +563,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagram_generator/config/while8.json
@@ -491,10 +491,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,
@@ -563,10 +563,10 @@
                           },
                           "variable": {
                             "metadata": {
-                              "label": "Name",
-                              "description": "Name of the variable"
+                              "label": "Variable",
+                              "description": "Name of the variable/field"
                             },
-                            "valueType": "IDENTIFIER",
+                            "valueType": "LV_EXPRESSION",
                             "value": "msg",
                             "optional": false,
                             "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/assign.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/node_template/config/assign.json
@@ -17,11 +17,10 @@
     "properties": {
       "variable": {
         "metadata": {
-          "label": "Name",
-          "description": "Name of the variable"
+          "label": "Variable",
+          "description": "Name of the variable/field"
         },
-        "valueType": "IDENTIFIER",
-        "value": "var1",
+        "valueType": "LV_EXPRESSION",
         "optional": false,
         "editable": true,
         "advanced": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if1.json
@@ -219,10 +219,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "i",
                     "optional": false,
                     "editable": true,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/suggested_flow_model/config/if2.json
@@ -297,10 +297,10 @@
                   },
                   "variable": {
                     "metadata": {
-                      "label": "Name",
-                      "description": "Name of the variable"
+                      "label": "Variable",
+                      "description": "Name of the variable/field"
                     },
-                    "valueType": "IDENTIFIER",
+                    "valueType": "LV_EXPRESSION",
                     "value": "i",
                     "optional": false,
                     "editable": true,


### PR DESCRIPTION
## Purpose
Currently, the variable of the assign node is rendered as an identifier, which causes invalid validations in the form. This is now differentiated with `LV_EXPRESSION` and specific validations are added with this PR.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/145


https://github.com/user-attachments/assets/4f3314e4-5be7-491c-97ff-980d60a4c9f9

