### PR TITLE
Remove duplicate type completions from the `expressionEditor/types`

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -50,8 +50,8 @@ import java.util.Optional;
 public class TypesGenerator {
 
     private final Map<String, TypeSymbol> typeSymbolMap;
-    private final Map<TypeSymbol, CompletionItem> completionItemMap;
-    private final Map<TypeSymbol, List<CompletionItem>> subtypeItemsMap;
+    private final Map<String, CompletionItem> completionItemMap;
+    private final Map<String, List<CompletionItem>> subtypeItemsMap;
     private volatile boolean initialized = false;
     private static final String LANG_ANNOTATIONS_MODULE = "lang.annotations";
 
@@ -179,7 +179,7 @@ public class TypesGenerator {
             completionItems.addAll(completionItemMap.values());
         } else {
             // Add the subtype builtin types
-            List<CompletionItem> subtypeItems = subtypeItemsMap.get(typeConstraintSymbol);
+            List<CompletionItem> subtypeItems = subtypeItemsMap.get(typeConstraintSymbol.signature());
             if (subtypeItems != null) {
                 completionItems.addAll(subtypeItems);
             }
@@ -202,7 +202,8 @@ public class TypesGenerator {
             return true;
         }
         try {
-            return !childTypeSymbol.subtypeOf(typeConstraintSymbol) || completionItemMap.containsKey(childTypeSymbol);
+            return !childTypeSymbol.subtypeOf(typeConstraintSymbol) ||
+                    completionItemMap.containsKey(childTypeSymbol.signature());
         } catch (Throwable ignored) {
             return true;
         }
@@ -241,7 +242,8 @@ public class TypesGenerator {
             typeSymbolMap.put(TYPE_FUTURE, types.FUTURE);
             typeSymbolMap.put(TYPE_TYPEDESC, types.TYPEDESC);
             typeSymbolMap.put(TYPE_HANDLE, types.HANDLE);
-            typeSymbolMap.put(TYPE_STREAM, types.STREAM);
+            typeSymbolMap.put(TYPE_STREAM,
+                    types.builder().STREAM_TYPE.withValueType(types.ANYDATA).withCompletionType(types.ERROR).build());
             typeSymbolMap.put(TYPE_READONLY, types.READONLY);
             typeSymbolMap.put(TYPE_RECORD, types.builder().RECORD_TYPE.withRestField(types.ANYDATA).build());
             typeSymbolMap.put(TYPE_MAP_JSON, types.builder().MAP_TYPE.withTypeParam(types.JSON).build());
@@ -254,7 +256,8 @@ public class TypesGenerator {
             categoryMap.forEach((category, typeNames) -> {
                 typeNames.forEach(typeName -> {
                     TypeSymbol symbol = typeSymbolMap.get(typeName);
-                    completionItemMap.put(symbol, TypeCompletionItemBuilder.build(symbol, typeName, category));
+                    completionItemMap.put(symbol.signature(),
+                            TypeCompletionItemBuilder.build(symbol, typeName, category));
                 });
             });
 
@@ -262,9 +265,9 @@ public class TypesGenerator {
             typeSymbolMap.forEach((name, symbol) -> {
                 List<CompletionItem> completionsList = typeSymbolMap.values().stream()
                         .filter(typeSymbol -> typeSymbol.subtypeOf(symbol))
-                        .map(completionItemMap::get)
+                        .map(typeSymbol -> completionItemMap.get(typeSymbol.signature()))
                         .toList();
-                subtypeItemsMap.put(symbol, completionsList);
+                subtypeItemsMap.put(symbol.signature(), completionsList);
             });
 
             initialized = true;

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -213,7 +213,7 @@ public class TypesGenerator {
         return Optional.ofNullable(typeSymbolMap.get(typeName));
     }
 
-    private void initializeBuiltinTypes(SemanticModel semanticModel) {
+    private synchronized void initializeBuiltinTypes(SemanticModel semanticModel) {
         if (initialized) {
             return;
         }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -158,11 +158,13 @@ public class TypesGenerator {
                 if (isInvalidTypeSymbol(symbol, typeConstraintSymbol)) {
                     continue;
                 }
+
                 // Skip the internal type definitions
                 if (symbol.getModule().map(moduleSymbol -> moduleSymbol.nameEquals(LANG_ANNOTATIONS_MODULE))
                         .orElse(false)) {
                     continue;
                 }
+
                 completionItems.add(TypeCompletionItemBuilder.build(
                         symbol,
                         symbol.getName().orElse(""),
@@ -185,7 +187,7 @@ public class TypesGenerator {
         return Either.forLeft(completionItems);
     }
 
-    private static boolean isInvalidTypeSymbol(Symbol symbol, TypeSymbol typeConstraintSymbol) {
+    private boolean isInvalidTypeSymbol(Symbol symbol, TypeSymbol typeConstraintSymbol) {
         if (typeConstraintSymbol == null) {
             return false;
         }
@@ -200,7 +202,7 @@ public class TypesGenerator {
             return true;
         }
         try {
-            return !childTypeSymbol.subtypeOf(typeConstraintSymbol);
+            return !childTypeSymbol.subtypeOf(typeConstraintSymbol) || completionItemMap.containsKey(childTypeSymbol);
         } catch (Throwable ignored) {
             return true;
         }

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/TypesGenerator.java
@@ -209,12 +209,7 @@ public class TypesGenerator {
         }
     }
 
-    public Optional<TypeSymbol> getTypeSymbol(SemanticModel semanticModel, String typeName) {
-        initializeBuiltinTypes(semanticModel);
-        return Optional.ofNullable(typeSymbolMap.get(typeName));
-    }
-
-    private synchronized void initializeBuiltinTypes(SemanticModel semanticModel) {
+    private void initializeBuiltinTypes(SemanticModel semanticModel) {
         if (initialized) {
             return;
         }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config11.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config11.json
@@ -17,13 +17,13 @@
       "insertText": "Person[]"
     },
     {
-      "label": "string[]",
+      "label": "Person",
       "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Array"
+        "detail": "User-Defined",
+        "description": "Record"
       },
-      "kind": "TypeParameter",
-      "insertText": "string[]"
+      "kind": "Struct",
+      "insertText": "Person"
     },
     {
       "label": "string|int",
@@ -42,15 +42,6 @@
       },
       "kind": "TypeParameter",
       "insertText": "map<Person>"
-    },
-    {
-      "label": "Person",
-      "labelDetails": {
-        "detail": "User-Defined",
-        "description": "Record"
-      },
-      "kind": "Struct",
-      "insertText": "Person"
     },
     {
       "label": "string",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config12.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config12.json
@@ -10,15 +10,6 @@
     {
       "label": "string[]",
       "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Array"
-      },
-      "kind": "TypeParameter",
-      "insertText": "string[]"
-    },
-    {
-      "label": "string[]",
-      "labelDetails": {
         "detail": "Structural Types",
         "description": "Array"
       },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config5.json
@@ -70,33 +70,6 @@
       "insertText": "Admission"
     },
     {
-      "label": "boolean",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Boolean"
-      },
-      "kind": "TypeParameter",
-      "insertText": "boolean"
-    },
-    {
-      "label": "string",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "String"
-      },
-      "kind": "TypeParameter",
-      "insertText": "string"
-    },
-    {
-      "label": "int",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Int"
-      },
-      "kind": "TypeParameter",
-      "insertText": "int"
-    },
-    {
       "label": "Input & readonly",
       "labelDetails": {
         "detail": "Used Variable Types",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config6.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config6.json
@@ -70,33 +70,6 @@
       "insertText": "Admission"
     },
     {
-      "label": "boolean",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Boolean"
-      },
-      "kind": "TypeParameter",
-      "insertText": "boolean"
-    },
-    {
-      "label": "string",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "String"
-      },
-      "kind": "TypeParameter",
-      "insertText": "string"
-    },
-    {
-      "label": "int",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Int"
-      },
-      "kind": "TypeParameter",
-      "insertText": "int"
-    },
-    {
       "label": "Input & readonly",
       "labelDetails": {
         "detail": "Used Variable Types",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config7.json
@@ -79,33 +79,6 @@
       "insertText": "http:Client"
     },
     {
-      "label": "boolean",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Boolean"
-      },
-      "kind": "TypeParameter",
-      "insertText": "boolean"
-    },
-    {
-      "label": "string",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "String"
-      },
-      "kind": "TypeParameter",
-      "insertText": "string"
-    },
-    {
-      "label": "int",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Int"
-      },
-      "kind": "TypeParameter",
-      "insertText": "int"
-    },
-    {
       "label": "Input & readonly",
       "labelDetails": {
         "detail": "Used Variable Types",

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config8.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/config8.json
@@ -6,15 +6,6 @@
     {
       "label": "string",
       "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "String"
-      },
-      "kind": "TypeParameter",
-      "insertText": "string"
-    },
-    {
-      "label": "string",
-      "labelDetails": {
         "detail": "Primitive Types",
         "description": "String"
       },

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/non_existence.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/types/config/non_existence.json
@@ -70,33 +70,6 @@
       "insertText": "Admission"
     },
     {
-      "label": "boolean",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Boolean"
-      },
-      "kind": "TypeParameter",
-      "insertText": "boolean"
-    },
-    {
-      "label": "string",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "String"
-      },
-      "kind": "TypeParameter",
-      "insertText": "string"
-    },
-    {
-      "label": "int",
-      "labelDetails": {
-        "detail": "Used Variable Types",
-        "description": "Int"
-      },
-      "kind": "TypeParameter",
-      "insertText": "int"
-    },
-    {
       "label": "Input & readonly",
       "labelDetails": {
         "detail": "Used Variable Types",


### PR DESCRIPTION
## Purpose
$title since having two types with the same label may confuse users.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/225