### PR TITLE
Add concurrency settings to build workflows

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -9,6 +9,9 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: ${{ github.head_ref }}-ubuntu
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,6 +53,9 @@ jobs:
   windows-build:
     runs-on: windows-latest
     timeout-minutes: 60
+    concurrency:
+      group: ${{ github.head_ref }}-windows
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: ${{ github.head_ref }}-ubuntu
+      group: ${{ github.ref_name }}-ubuntu
       cancel-in-progress: true
     steps:
       - name: Checkout repository
@@ -54,7 +54,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     concurrency:
-      group: ${{ github.head_ref }}-windows
+      group: ${{ github.ref_name }}-windows
       cancel-in-progress: true
     steps:
       - name: Checkout repository

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,9 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: ${{ github.head_ref }}-ubuntu
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,6 +50,9 @@ jobs:
   windows-build:
     runs-on: windows-latest
     timeout-minutes: 60
+    concurrency:
+      group: ${{ github.head_ref }}-windows
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Purpose
$title to avoid outdated runs for the previous commits.