### PR TITLE
Remove unused log imports when generating source code for automations

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AutomationBuilder.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/model/node/AutomationBuilder.java
@@ -26,6 +26,7 @@ import io.ballerina.flowmodelgenerator.core.model.NodeBuilder;
 import io.ballerina.flowmodelgenerator.core.model.NodeKind;
 import io.ballerina.flowmodelgenerator.core.model.Property;
 import io.ballerina.flowmodelgenerator.core.model.SourceBuilder;
+import io.ballerina.modelgenerator.commons.CommonUtils;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.model.types.TypeKind;
 import org.eclipse.lsp4j.TextEdit;
@@ -54,7 +55,7 @@ public class AutomationBuilder extends FunctionDefinitionBuilder {
     public static final String RETURN_ERROR_LABEL = "Return Error";
     public static final String RETURN_ERROR_DOC = "Indicate if the automation should exit with error";
 
-    private static final String AUTOMATIONS_BAL = "automation.bal";
+    private static final String BALLERINA_LOG_MODULE = "log";
     private static final String DEFAULT_BODY =
             "do {\n} on fail error e {\n  log:printError(\"Error occurred\", 'error=e);\n   return e;\n}";
     private static final List<String> TYPE_CONSTRAINT = List.of(
@@ -161,11 +162,11 @@ public class AutomationBuilder extends FunctionDefinitionBuilder {
             sourceBuilder.token().openBrace();
             if (hasReturnError) {
                 sourceBuilder.token().name(DEFAULT_BODY);
+                sourceBuilder.acceptImport(CommonUtils.BALLERINA_ORG_NAME, BALLERINA_LOG_MODULE);
             }
             sourceBuilder.token().closeBrace()
                     .stepOut()
                     .textEdit(SourceBuilder.SourceKind.DECLARATION);
-            sourceBuilder.acceptImport("ballerina", "log");
         } else {
             sourceBuilder
                     .token().skipFormatting().stepOut()

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/automation_definition4.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/to_source/config/automation_definition4.json
@@ -1,0 +1,231 @@
+{
+  "source": "function_definition/main.bal",
+  "description": "Sample diagram node",
+  "diagram": {
+    "id": "33772",
+    "metadata": {
+      "label": "Automation",
+      "description": "Define an automation"
+    },
+    "codedata": {
+      "node": "AUTOMATION",
+      "isNew": true
+    },
+    "returning": false,
+    "properties": {
+      "functionName": {
+        "metadata": {
+          "label": "Name",
+          "description": "Name of the function"
+        },
+        "valueType": "IDENTIFIER",
+        "value": "main",
+        "optional": false,
+        "editable": false,
+        "advanced": false,
+        "hidden": true
+      },
+      "parameters": {
+        "metadata": {
+          "label": "Startup Parameters",
+          "description": "Define the parameters to be passed to the automation at startup"
+        },
+        "valueType": "REPEATABLE_PROPERTY",
+        "valueTypeConstraint": {
+          "metadata": {
+            "label": "Parameter",
+            "description": "Function parameter"
+          },
+          "valueType": "FIXED_PROPERTY",
+          "value": {
+            "type": {
+              "metadata": {
+                "label": "Variable Type",
+                "description": "Type of the variable"
+              },
+              "valueType": "SINGLE_SELECT",
+              "valueTypeConstraint": [
+                "string",
+                "int",
+                "float",
+                "decimal",
+                "byte"
+              ],
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false,
+              "hidden": false
+            },
+            "variable": {
+              "metadata": {
+                "label": "Variable Name",
+                "description": "Name of the variable"
+              },
+              "valueType": "IDENTIFIER",
+              "value": "",
+              "optional": false,
+              "editable": true,
+              "advanced": false,
+              "hidden": false
+            }
+          },
+          "optional": false,
+          "editable": false,
+          "advanced": false,
+          "hidden": false
+        },
+        "value": {
+          "name": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "SINGLE_SELECT",
+                "valueTypeConstraint": [
+                  "string",
+                  "int",
+                  "float",
+                  "decimal",
+                  "byte"
+                ],
+                "value": "string",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "name",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false,
+                "codedata": {
+                  "lineRange": {
+                    "fileName": "main2.bal",
+                    "startLine": {
+                      "line": 2,
+                      "offset": 28
+                    },
+                    "endLine": {
+                      "line": 2,
+                      "offset": 32
+                    }
+                  }
+                }
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false,
+            "hidden": false
+          },
+          "age": {
+            "metadata": {
+              "label": "Parameter",
+              "description": "Function parameter"
+            },
+            "valueType": "FIXED_PROPERTY",
+            "value": {
+              "type": {
+                "metadata": {
+                  "label": "Variable Type",
+                  "description": "Type of the variable"
+                },
+                "valueType": "SINGLE_SELECT",
+                "valueTypeConstraint": [
+                  "string",
+                  "int",
+                  "float",
+                  "decimal",
+                  "byte"
+                ],
+                "value": "int?",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false
+              },
+              "variable": {
+                "metadata": {
+                  "label": "Variable Name",
+                  "description": "Name of the variable"
+                },
+                "valueType": "IDENTIFIER",
+                "value": "age",
+                "optional": false,
+                "editable": true,
+                "advanced": false,
+                "hidden": false,
+                "codedata": {
+                  "lineRange": {
+                    "fileName": "main2.bal",
+                    "startLine": {
+                      "line": 2,
+                      "offset": 39
+                    },
+                    "endLine": {
+                      "line": 2,
+                      "offset": 42
+                    }
+                  }
+                }
+              }
+            },
+            "optional": false,
+            "editable": false,
+            "advanced": false,
+            "hidden": false
+          }
+        },
+        "optional": true,
+        "editable": false,
+        "advanced": false,
+        "hidden": false
+      },
+      "returnError": {
+        "metadata": {
+          "label": "Return Error",
+          "description": "Indicate if the automation should exit with error"
+        },
+        "valueType": "FLAG",
+        "value": false,
+        "optional": false,
+        "editable": true,
+        "advanced": false,
+        "hidden": false
+      }
+    },
+    "flags": 0
+  },
+  "output": {
+    "function_definition/automation.bal": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 0,
+            "character": 0
+          }
+        },
+        "newText": "public function main(string name, int? age) {\n}"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Purpose

$title when generating a new automation without the return error, since there is no logging.

Fixes https://github.com/wso2/ballerina-vscode/issues/594