### PR TITLE
Allow underscore `_` in variable names for the assign node

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/LvExpressionDiagnosticRequest.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/expressioneditor/services/LvExpressionDiagnosticRequest.java
@@ -47,6 +47,8 @@ public class LvExpressionDiagnosticRequest extends DiagnosticsRequest {
 
     private static final String INVALID_LHS = "Invalid expression for a variable reference '%s'";
     private static final DiagnosticErrorCode INVALID_EXPRESSION_CODE = DiagnosticErrorCode.INVALID_EXPR_STATEMENT;
+    private static final DiagnosticErrorCode UNDERSCORE_NOT_ALLOWED_CODE =
+            DiagnosticErrorCode.UNDERSCORE_NOT_ALLOWED_AS_IDENTIFIER;
 
     public LvExpressionDiagnosticRequest(ExpressionEditorContext context) {
         super(context);
@@ -105,7 +107,8 @@ public class LvExpressionDiagnosticRequest extends DiagnosticsRequest {
         Optional<SemanticModel> semanticModel =
                 context.workspaceManager().semanticModel(context.filePath());
         return semanticModel.map(model -> model.diagnostics(lineRange).stream()
-                .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR)
+                .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR
+                        && !UNDERSCORE_NOT_ALLOWED_CODE.diagnosticId().equals(diagnostic.diagnosticInfo().code()))
                 .map(CommonUtils::transformBallerinaDiagnostic)
                 .collect(Collectors.toSet())).orElseGet(Set::of);
     }

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign9.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/diagnostics/config/assign9.json
@@ -1,0 +1,40 @@
+{
+  "description": "",
+  "filePath": "source.bal",
+  "context": {
+    "expression": "_",
+    "startLine": {
+      "line": 1,
+      "offset": 0
+    },
+    "offset": 2,
+    "lineOffset": 0,
+    "codedata": {
+      "node": "VARIABLE",
+      "lineRange": {
+        "fileName": "new_data.bal",
+        "startLine": {
+          "line": 1,
+          "offset": 4
+        },
+        "endLine": {
+          "line": 1,
+          "offset": 14
+        }
+      },
+      "sourceCode": "int i = 12;"
+    },
+    "property": {
+      "metadata": {
+        "label": "Variable",
+        "description": "Name of the variable/field"
+      },
+      "valueType": "LV_EXPRESSION",
+      "value": "12",
+      "optional": true,
+      "editable": true,
+      "advanced": false
+    }
+  },
+  "diagnostics": []
+}


### PR DESCRIPTION
## Purpose
$title as the variable can be ignored by the user.

Fixes https://github.com/wso2/product-ballerina-integrator/issues/290

