### PR TITLE
[2201.12.x] Include only the type name in the Type object for visibleVariableTypes API variable types

### DIFF
--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/VisibleVariableTypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/VisibleVariableTypesGenerator.java
@@ -22,6 +22,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.PathParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -33,6 +34,8 @@ import io.ballerina.compiler.api.symbols.resourcepath.util.PathSegment;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.modelgenerator.commons.CommonUtils;
+import io.ballerina.modelgenerator.commons.ModuleInfo;
 import io.ballerina.projects.Document;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
@@ -84,7 +87,7 @@ public class VisibleVariableTypesGenerator {
             if (symbol.kind() == SymbolKind.VARIABLE) {
                 VariableSymbol variableSymbol = (VariableSymbol) symbol;
                 String name = variableSymbol.getName().orElse("");
-                Type type = Type.fromSemanticSymbol(variableSymbol);
+                Type type = fromTypeSymbol(variableSymbol.typeDescriptor());
 
                 // Skip the object types
                 TypeSymbol typeSymbol = variableSymbol.typeDescriptor();
@@ -108,12 +111,12 @@ public class VisibleVariableTypesGenerator {
                 }
             } else if (symbol.kind() == SymbolKind.PARAMETER) {
                 String name = symbol.getName().orElse("");
-                Type type = Type.fromSemanticSymbol(symbol);
+                Type type = fromTypeSymbol(((ParameterSymbol) symbol).typeDescriptor());
                 addCategoryValue(Category.PARAMETER_CATEGORY, name, type);
             } else if (symbol.kind() == SymbolKind.PATH_PARAMETER) {
                 String name = symbol.getName().orElse("");
                 PathParameterSymbol pathParameterSymbol = (PathParameterSymbol) symbol;
-                Type type = Type.fromSemanticSymbol(pathParameterSymbol.typeDescriptor());
+                Type type = fromTypeSymbol(pathParameterSymbol.typeDescriptor());
                 type.isRestType = pathParameterSymbol.pathSegmentKind() == PathSegment.Kind.PATH_REST_PARAMETER;
                 addCategoryValue(Category.PATH_PARAMETER_CATEGORY, name, type);
             }
@@ -130,6 +133,15 @@ public class VisibleVariableTypesGenerator {
         }
 
         return gson.toJsonTree(categories).getAsJsonArray();
+    }
+
+    private Type fromTypeSymbol(TypeSymbol typeSymbol) {
+        String typeName = CommonUtils.getTypeSignature(semanticModel, typeSymbol, false,
+                ModuleInfo.from(document.module().descriptor()));
+        Type newType = new Type();
+        newType.typeName = typeName;
+        newType.name = typeName;
+        return newType;
     }
 
     /**

--- a/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/VisibleVariableTypesGenerator.java
+++ b/flow-model-generator/modules/flow-model-generator-core/src/main/java/io/ballerina/flowmodelgenerator/core/VisibleVariableTypesGenerator.java
@@ -21,14 +21,22 @@ package io.ballerina.flowmodelgenerator.core;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
+import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.PathParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TableTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.api.symbols.resourcepath.util.PathSegment;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
@@ -139,9 +147,41 @@ public class VisibleVariableTypesGenerator {
         String typeName = CommonUtils.getTypeSignature(semanticModel, typeSymbol, false,
                 ModuleInfo.from(document.module().descriptor()));
         Type newType = new Type();
-        newType.typeName = typeName;
+        newType.typeName = getTypeName(typeSymbol);
         newType.name = typeName;
         return newType;
+    }
+
+    private String getTypeName(TypeSymbol typeSymbol) {
+        if (typeSymbol instanceof RecordTypeSymbol) {
+            return "record";
+        } else if (typeSymbol instanceof ArrayTypeSymbol) {
+            return "array";
+        } else if (typeSymbol instanceof MapTypeSymbol) {
+            return "map";
+        } else if (typeSymbol instanceof TableTypeSymbol) {
+            return "table";
+        } else if (typeSymbol instanceof UnionTypeSymbol) {
+            return "union";
+        } else if (typeSymbol instanceof ErrorTypeSymbol) {
+            return "error";
+        } else if (typeSymbol instanceof IntersectionTypeSymbol) {
+            return "intersection";
+        } else if (typeSymbol instanceof StreamTypeSymbol) {
+            return "stream";
+        } else if (typeSymbol instanceof ObjectTypeSymbol) {
+            return "object";
+        } else if (typeSymbol instanceof TypeReferenceTypeSymbol typeReferenceTypeSymbol) {
+            if (typeReferenceTypeSymbol.definition().kind().equals(SymbolKind.ENUM)) {
+                return "enum";
+            }
+            return getTypeName(typeReferenceTypeSymbol.typeDescriptor());
+        }
+        String typeName = typeSymbol.signature();
+        if (typeName.startsWith("\"") && typeName.endsWith("\"")) {
+            typeName = typeName.substring(1, typeName.length() - 1);
+        }
+        return typeName;
     }
 
     /**

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
@@ -13,7 +13,7 @@
           "name": "address",
           "type": {
             "name": "Address",
-            "typeName": "Address",
+            "typeName": "record",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -62,7 +62,7 @@
           "name": "moduleInput",
           "type": {
             "name": "Input",
-            "typeName": "Input",
+            "typeName": "record",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -78,7 +78,7 @@
           "name": "configInput",
           "type": {
             "name": "Input & readonly",
-            "typeName": "Input & readonly",
+            "typeName": "intersection",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -89,7 +89,7 @@
           "name": "configTable",
           "type": {
             "name": "table<Input> key(name) & readonly",
-            "typeName": "table<Input> key(name) & readonly",
+            "typeName": "intersection",
             "optional": false,
             "defaultable": false,
             "isRestType": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config1.json
@@ -12,63 +12,9 @@
         {
           "name": "address",
           "type": {
-            "fields": [
-              {
-                "name": "houseNo",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "line1",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "line2",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "city",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "country",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "hasRestType": false,
             "name": "Address",
-            "typeName": "record",
+            "typeName": "Address",
             "optional": false,
-            "typeInfo": {
-              "name": "Address",
-              "orgName": "nipunaf",
-              "moduleName": "new_connection1",
-              "version": "0.1.0"
-            },
             "defaultable": false,
             "isRestType": false,
             "selected": false
@@ -77,6 +23,7 @@
         {
           "name": "w",
           "type": {
+            "name": "boolean",
             "typeName": "boolean",
             "optional": false,
             "defaultable": false,
@@ -87,6 +34,7 @@
         {
           "name": "x",
           "type": {
+            "name": "int",
             "typeName": "int",
             "optional": false,
             "defaultable": false,
@@ -97,6 +45,7 @@
         {
           "name": "z",
           "type": {
+            "name": "string",
             "typeName": "string",
             "optional": false,
             "defaultable": false,
@@ -112,43 +61,9 @@
         {
           "name": "moduleInput",
           "type": {
-            "fields": [
-              {
-                "name": "name",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "age",
-                "typeName": "int",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "hasRestType": true,
-            "restType": {
-              "typeName": "anydata",
-              "optional": false,
-              "defaultable": false,
-              "isRestType": false,
-              "selected": false
-            },
             "name": "Input",
-            "typeName": "record",
+            "typeName": "Input",
             "optional": false,
-            "typeInfo": {
-              "name": "Input",
-              "orgName": "nipunaf",
-              "moduleName": "new_connection1",
-              "version": "0.1.0"
-            },
             "defaultable": false,
             "isRestType": false,
             "selected": false
@@ -162,58 +77,8 @@
         {
           "name": "configInput",
           "type": {
-            "members": [
-              {
-                "fields": [
-                  {
-                    "name": "name",
-                    "typeName": "string",
-                    "optional": false,
-                    "defaultable": false,
-                    "documentation": "",
-                    "isRestType": false,
-                    "selected": false
-                  },
-                  {
-                    "name": "age",
-                    "typeName": "int",
-                    "optional": false,
-                    "defaultable": false,
-                    "documentation": "",
-                    "isRestType": false,
-                    "selected": false
-                  }
-                ],
-                "hasRestType": true,
-                "restType": {
-                  "typeName": "anydata",
-                  "optional": false,
-                  "defaultable": false,
-                  "isRestType": false,
-                  "selected": false
-                },
-                "name": "Input",
-                "typeName": "record",
-                "optional": false,
-                "typeInfo": {
-                  "name": "Input",
-                  "orgName": "nipunaf",
-                  "moduleName": "new_connection1",
-                  "version": "0.1.0"
-                },
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "typeName": "readonly",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "typeName": "intersection",
+            "name": "Input & readonly",
+            "typeName": "Input & readonly",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -223,68 +88,8 @@
         {
           "name": "configTable",
           "type": {
-            "members": [
-              {
-                "rowType": {
-                  "fields": [
-                    {
-                      "name": "name",
-                      "typeName": "string",
-                      "optional": false,
-                      "defaultable": false,
-                      "documentation": "",
-                      "isRestType": false,
-                      "selected": false
-                    },
-                    {
-                      "name": "age",
-                      "typeName": "int",
-                      "optional": false,
-                      "defaultable": false,
-                      "documentation": "",
-                      "isRestType": false,
-                      "selected": false
-                    }
-                  ],
-                  "hasRestType": true,
-                  "restType": {
-                    "typeName": "anydata",
-                    "optional": false,
-                    "defaultable": false,
-                    "isRestType": false,
-                    "selected": false
-                  },
-                  "name": "Input",
-                  "typeName": "record",
-                  "optional": false,
-                  "typeInfo": {
-                    "name": "Input",
-                    "orgName": "nipunaf",
-                    "moduleName": "new_connection1",
-                    "version": "0.1.0"
-                  },
-                  "defaultable": false,
-                  "isRestType": false,
-                  "selected": false
-                },
-                "keys": [
-                  "name"
-                ],
-                "typeName": "table",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "typeName": "readonly",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "typeName": "intersection",
+            "name": "table<Input> key(name) & readonly",
+            "typeName": "table<Input> key(name) & readonly",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -294,6 +99,7 @@
         {
           "name": "serviceName",
           "type": {
+            "name": "string",
             "typeName": "string",
             "optional": false,
             "defaultable": false,
@@ -304,6 +110,7 @@
         {
           "name": "servicePort",
           "type": {
+            "name": "int",
             "typeName": "int",
             "optional": false,
             "defaultable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
@@ -12,43 +12,9 @@
         {
           "name": "localInput",
           "type": {
-            "fields": [
-              {
-                "name": "name",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "age",
-                "typeName": "int",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "hasRestType": true,
-            "restType": {
-              "typeName": "anydata",
-              "optional": false,
-              "defaultable": false,
-              "isRestType": false,
-              "selected": false
-            },
             "name": "Input",
-            "typeName": "record",
+            "typeName": "Input",
             "optional": false,
-            "typeInfo": {
-              "name": "Input",
-              "orgName": "nipunaf",
-              "moduleName": "new_connection1",
-              "version": "0.1.0"
-            },
             "defaultable": false,
             "isRestType": false,
             "selected": false
@@ -62,43 +28,9 @@
         {
           "name": "moduleInput",
           "type": {
-            "fields": [
-              {
-                "name": "name",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "age",
-                "typeName": "int",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "hasRestType": true,
-            "restType": {
-              "typeName": "anydata",
-              "optional": false,
-              "defaultable": false,
-              "isRestType": false,
-              "selected": false
-            },
             "name": "Input",
-            "typeName": "record",
+            "typeName": "Input",
             "optional": false,
-            "typeInfo": {
-              "name": "Input",
-              "orgName": "nipunaf",
-              "moduleName": "new_connection1",
-              "version": "0.1.0"
-            },
             "defaultable": false,
             "isRestType": false,
             "selected": false
@@ -107,6 +39,7 @@
         {
           "name": "w",
           "type": {
+            "name": "boolean",
             "typeName": "boolean",
             "optional": false,
             "defaultable": false,
@@ -122,58 +55,8 @@
         {
           "name": "configInput",
           "type": {
-            "members": [
-              {
-                "fields": [
-                  {
-                    "name": "name",
-                    "typeName": "string",
-                    "optional": false,
-                    "defaultable": false,
-                    "documentation": "",
-                    "isRestType": false,
-                    "selected": false
-                  },
-                  {
-                    "name": "age",
-                    "typeName": "int",
-                    "optional": false,
-                    "defaultable": false,
-                    "documentation": "",
-                    "isRestType": false,
-                    "selected": false
-                  }
-                ],
-                "hasRestType": true,
-                "restType": {
-                  "typeName": "anydata",
-                  "optional": false,
-                  "defaultable": false,
-                  "isRestType": false,
-                  "selected": false
-                },
-                "name": "Input",
-                "typeName": "record",
-                "optional": false,
-                "typeInfo": {
-                  "name": "Input",
-                  "orgName": "nipunaf",
-                  "moduleName": "new_connection1",
-                  "version": "0.1.0"
-                },
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "typeName": "readonly",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "typeName": "intersection",
+            "name": "Input & readonly",
+            "typeName": "Input & readonly",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -183,68 +66,8 @@
         {
           "name": "configTable",
           "type": {
-            "members": [
-              {
-                "rowType": {
-                  "fields": [
-                    {
-                      "name": "name",
-                      "typeName": "string",
-                      "optional": false,
-                      "defaultable": false,
-                      "documentation": "",
-                      "isRestType": false,
-                      "selected": false
-                    },
-                    {
-                      "name": "age",
-                      "typeName": "int",
-                      "optional": false,
-                      "defaultable": false,
-                      "documentation": "",
-                      "isRestType": false,
-                      "selected": false
-                    }
-                  ],
-                  "hasRestType": true,
-                  "restType": {
-                    "typeName": "anydata",
-                    "optional": false,
-                    "defaultable": false,
-                    "isRestType": false,
-                    "selected": false
-                  },
-                  "name": "Input",
-                  "typeName": "record",
-                  "optional": false,
-                  "typeInfo": {
-                    "name": "Input",
-                    "orgName": "nipunaf",
-                    "moduleName": "new_connection1",
-                    "version": "0.1.0"
-                  },
-                  "defaultable": false,
-                  "isRestType": false,
-                  "selected": false
-                },
-                "keys": [
-                  "name"
-                ],
-                "typeName": "table",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "typeName": "readonly",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "typeName": "intersection",
+            "name": "table<Input> key(name) & readonly",
+            "typeName": "table<Input> key(name) & readonly",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -254,6 +77,7 @@
         {
           "name": "serviceName",
           "type": {
+            "name": "string",
             "typeName": "string",
             "optional": false,
             "defaultable": false,
@@ -264,6 +88,7 @@
         {
           "name": "servicePort",
           "type": {
+            "name": "int",
             "typeName": "int",
             "optional": false,
             "defaultable": false,
@@ -279,9 +104,10 @@
         {
           "name": "i",
           "type": {
+            "name": "int",
             "typeName": "int",
             "optional": false,
-            "defaultable": true,
+            "defaultable": false,
             "isRestType": false,
             "selected": false
           }
@@ -289,6 +115,7 @@
         {
           "name": "value",
           "type": {
+            "name": "string",
             "typeName": "string",
             "optional": false,
             "defaultable": false,
@@ -304,6 +131,7 @@
         {
           "name": "user",
           "type": {
+            "name": "string",
             "typeName": "string",
             "optional": false,
             "defaultable": false,
@@ -314,6 +142,7 @@
         {
           "name": "val",
           "type": {
+            "name": "int",
             "typeName": "int",
             "optional": false,
             "defaultable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config2.json
@@ -13,7 +13,7 @@
           "name": "localInput",
           "type": {
             "name": "Input",
-            "typeName": "Input",
+            "typeName": "record",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -29,7 +29,7 @@
           "name": "moduleInput",
           "type": {
             "name": "Input",
-            "typeName": "Input",
+            "typeName": "record",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -56,7 +56,7 @@
           "name": "configInput",
           "type": {
             "name": "Input & readonly",
-            "typeName": "Input & readonly",
+            "typeName": "intersection",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -67,7 +67,7 @@
           "name": "configTable",
           "type": {
             "name": "table<Input> key(name) & readonly",
-            "typeName": "table<Input> key(name) & readonly",
+            "typeName": "intersection",
             "optional": false,
             "defaultable": false,
             "isRestType": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config3.json
@@ -12,7 +12,8 @@
         {
           "name": "cl",
           "type": {
-            "typeName": "$CompilationError$",
+            "name": "Unknown Type",
+            "typeName": "Unknown Type",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -22,6 +23,7 @@
         {
           "name": "name",
           "type": {
+            "name": "string",
             "typeName": "string",
             "optional": false,
             "defaultable": false,
@@ -37,43 +39,9 @@
         {
           "name": "moduleInput",
           "type": {
-            "fields": [
-              {
-                "name": "name",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "age",
-                "typeName": "int",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "hasRestType": true,
-            "restType": {
-              "typeName": "anydata",
-              "optional": false,
-              "defaultable": false,
-              "isRestType": false,
-              "selected": false
-            },
             "name": "Input",
-            "typeName": "record",
+            "typeName": "Input",
             "optional": false,
-            "typeInfo": {
-              "name": "Input",
-              "orgName": "nipunaf",
-              "moduleName": "new_connection1",
-              "version": "0.1.0"
-            },
             "defaultable": false,
             "isRestType": false,
             "selected": false
@@ -82,6 +50,7 @@
         {
           "name": "w",
           "type": {
+            "name": "boolean",
             "typeName": "boolean",
             "optional": false,
             "defaultable": false,
@@ -97,58 +66,8 @@
         {
           "name": "configInput",
           "type": {
-            "members": [
-              {
-                "fields": [
-                  {
-                    "name": "name",
-                    "typeName": "string",
-                    "optional": false,
-                    "defaultable": false,
-                    "documentation": "",
-                    "isRestType": false,
-                    "selected": false
-                  },
-                  {
-                    "name": "age",
-                    "typeName": "int",
-                    "optional": false,
-                    "defaultable": false,
-                    "documentation": "",
-                    "isRestType": false,
-                    "selected": false
-                  }
-                ],
-                "hasRestType": true,
-                "restType": {
-                  "typeName": "anydata",
-                  "optional": false,
-                  "defaultable": false,
-                  "isRestType": false,
-                  "selected": false
-                },
-                "name": "Input",
-                "typeName": "record",
-                "optional": false,
-                "typeInfo": {
-                  "name": "Input",
-                  "orgName": "nipunaf",
-                  "moduleName": "new_connection1",
-                  "version": "0.1.0"
-                },
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "typeName": "readonly",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "typeName": "intersection",
+            "name": "Input & readonly",
+            "typeName": "Input & readonly",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -158,68 +77,8 @@
         {
           "name": "configTable",
           "type": {
-            "members": [
-              {
-                "rowType": {
-                  "fields": [
-                    {
-                      "name": "name",
-                      "typeName": "string",
-                      "optional": false,
-                      "defaultable": false,
-                      "documentation": "",
-                      "isRestType": false,
-                      "selected": false
-                    },
-                    {
-                      "name": "age",
-                      "typeName": "int",
-                      "optional": false,
-                      "defaultable": false,
-                      "documentation": "",
-                      "isRestType": false,
-                      "selected": false
-                    }
-                  ],
-                  "hasRestType": true,
-                  "restType": {
-                    "typeName": "anydata",
-                    "optional": false,
-                    "defaultable": false,
-                    "isRestType": false,
-                    "selected": false
-                  },
-                  "name": "Input",
-                  "typeName": "record",
-                  "optional": false,
-                  "typeInfo": {
-                    "name": "Input",
-                    "orgName": "nipunaf",
-                    "moduleName": "new_connection1",
-                    "version": "0.1.0"
-                  },
-                  "defaultable": false,
-                  "isRestType": false,
-                  "selected": false
-                },
-                "keys": [
-                  "name"
-                ],
-                "typeName": "table",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "typeName": "readonly",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "typeName": "intersection",
+            "name": "table<Input> key(name) & readonly",
+            "typeName": "table<Input> key(name) & readonly",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -229,6 +88,7 @@
         {
           "name": "serviceName",
           "type": {
+            "name": "string",
             "typeName": "string",
             "optional": false,
             "defaultable": false,
@@ -239,6 +99,7 @@
         {
           "name": "servicePort",
           "type": {
+            "name": "int",
             "typeName": "int",
             "optional": false,
             "defaultable": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config3.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/config3.json
@@ -13,7 +13,7 @@
           "name": "cl",
           "type": {
             "name": "Unknown Type",
-            "typeName": "Unknown Type",
+            "typeName": "$CompilationError$",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -40,7 +40,7 @@
           "name": "moduleInput",
           "type": {
             "name": "Input",
-            "typeName": "Input",
+            "typeName": "record",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -67,7 +67,7 @@
           "name": "configInput",
           "type": {
             "name": "Input & readonly",
-            "typeName": "Input & readonly",
+            "typeName": "intersection",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -78,7 +78,7 @@
           "name": "configTable",
           "type": {
             "name": "table<Input> key(name) & readonly",
-            "typeName": "table<Input> key(name) & readonly",
+            "typeName": "intersection",
             "optional": false,
             "defaultable": false,
             "isRestType": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/non_existence.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/non_existence.json
@@ -9,7 +9,7 @@
           "name": "moduleInput",
           "type": {
             "name": "Input",
-            "typeName": "Input",
+            "typeName": "record",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -36,7 +36,7 @@
           "name": "configInput",
           "type": {
             "name": "Input & readonly",
-            "typeName": "Input & readonly",
+            "typeName": "intersection",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -47,7 +47,7 @@
           "name": "configTable",
           "type": {
             "name": "table<Input> key(name) & readonly",
-            "typeName": "table<Input> key(name) & readonly",
+            "typeName": "intersection",
             "optional": false,
             "defaultable": false,
             "isRestType": false,

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/non_existence.json
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/src/test/resources/visible_variable_types/config/non_existence.json
@@ -8,43 +8,9 @@
         {
           "name": "moduleInput",
           "type": {
-            "fields": [
-              {
-                "name": "name",
-                "typeName": "string",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "name": "age",
-                "typeName": "int",
-                "optional": false,
-                "defaultable": false,
-                "documentation": "",
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "hasRestType": true,
-            "restType": {
-              "typeName": "anydata",
-              "optional": false,
-              "defaultable": false,
-              "isRestType": false,
-              "selected": false
-            },
             "name": "Input",
-            "typeName": "record",
+            "typeName": "Input",
             "optional": false,
-            "typeInfo": {
-              "name": "Input",
-              "orgName": "nipunaf",
-              "moduleName": "new_connection1",
-              "version": "0.1.0"
-            },
             "defaultable": false,
             "isRestType": false,
             "selected": false
@@ -53,6 +19,7 @@
         {
           "name": "w",
           "type": {
+            "name": "boolean",
             "typeName": "boolean",
             "optional": false,
             "defaultable": false,
@@ -68,58 +35,8 @@
         {
           "name": "configInput",
           "type": {
-            "members": [
-              {
-                "fields": [
-                  {
-                    "name": "name",
-                    "typeName": "string",
-                    "optional": false,
-                    "defaultable": false,
-                    "documentation": "",
-                    "isRestType": false,
-                    "selected": false
-                  },
-                  {
-                    "name": "age",
-                    "typeName": "int",
-                    "optional": false,
-                    "defaultable": false,
-                    "documentation": "",
-                    "isRestType": false,
-                    "selected": false
-                  }
-                ],
-                "hasRestType": true,
-                "restType": {
-                  "typeName": "anydata",
-                  "optional": false,
-                  "defaultable": false,
-                  "isRestType": false,
-                  "selected": false
-                },
-                "name": "Input",
-                "typeName": "record",
-                "optional": false,
-                "typeInfo": {
-                  "name": "Input",
-                  "orgName": "nipunaf",
-                  "moduleName": "new_connection1",
-                  "version": "0.1.0"
-                },
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "typeName": "readonly",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "typeName": "intersection",
+            "name": "Input & readonly",
+            "typeName": "Input & readonly",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -129,68 +46,8 @@
         {
           "name": "configTable",
           "type": {
-            "members": [
-              {
-                "rowType": {
-                  "fields": [
-                    {
-                      "name": "name",
-                      "typeName": "string",
-                      "optional": false,
-                      "defaultable": false,
-                      "documentation": "",
-                      "isRestType": false,
-                      "selected": false
-                    },
-                    {
-                      "name": "age",
-                      "typeName": "int",
-                      "optional": false,
-                      "defaultable": false,
-                      "documentation": "",
-                      "isRestType": false,
-                      "selected": false
-                    }
-                  ],
-                  "hasRestType": true,
-                  "restType": {
-                    "typeName": "anydata",
-                    "optional": false,
-                    "defaultable": false,
-                    "isRestType": false,
-                    "selected": false
-                  },
-                  "name": "Input",
-                  "typeName": "record",
-                  "optional": false,
-                  "typeInfo": {
-                    "name": "Input",
-                    "orgName": "nipunaf",
-                    "moduleName": "new_connection1",
-                    "version": "0.1.0"
-                  },
-                  "defaultable": false,
-                  "isRestType": false,
-                  "selected": false
-                },
-                "keys": [
-                  "name"
-                ],
-                "typeName": "table",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              },
-              {
-                "typeName": "readonly",
-                "optional": false,
-                "defaultable": false,
-                "isRestType": false,
-                "selected": false
-              }
-            ],
-            "typeName": "intersection",
+            "name": "table<Input> key(name) & readonly",
+            "typeName": "table<Input> key(name) & readonly",
             "optional": false,
             "defaultable": false,
             "isRestType": false,
@@ -200,6 +57,7 @@
         {
           "name": "serviceName",
           "type": {
+            "name": "string",
             "typeName": "string",
             "optional": false,
             "defaultable": false,
@@ -210,6 +68,7 @@
         {
           "name": "servicePort",
           "type": {
+            "name": "int",
             "typeName": "int",
             "optional": false,
             "defaultable": false,


### PR DESCRIPTION
## Purpose
$subject

Fixes [OOM occurs when trying to return a value using BI](https://github.com/wso2-enterprise/internal-support-ballerina/issues/979)

The `visibleVariableTypes` API is used in the expression editor's helper pane, where we display visible variable symbols grouped under different categories. Currently, this helper pane only uses the `Type` object to show the type name alongside each variable.

However, the existing implementation of the `Type` object includes additional type information, which is unnecessary for this use case and can lead to performance issues, as noted in [this comment](https://github.com/wso2-enterprise/internal-support-ballerina/issues/979#issuecomment-2894468121).

With this PR, we simplify the response by including only the type name in the `Type` object associated with each variable.


https://github.com/user-attachments/assets/2478b230-224c-4d90-a765-7f67e3e91ff6


