### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           node-version: '23.11.0'
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21.0.3
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -62,11 +62,11 @@ jobs:
         with:
           node-version: '23.11.0'
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21.0.3
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/architecture-model-generator/modules/architecture-model-generator-core/build.gradle
+++ b/architecture-model-generator/modules/architecture-model-generator-core/build.gradle
@@ -45,13 +45,13 @@ dependencies {
     }
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -64,7 +64,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -75,7 +75,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/architecture-model-generator/modules/architecture-model-generator-core/build.gradle
+++ b/architecture-model-generator/modules/architecture-model-generator-core/build.gradle
@@ -99,6 +99,7 @@ test {
     useTestNG() {
         suites "src/test/resources/testng.xml"
     }
+    failOnNoDiscoveredTests = false
 }
 
 ext.moduleName = 'io.ballerina.architecturemodelgenerator.core'

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/build.gradle
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/build.gradle
@@ -51,13 +51,13 @@ dependencies {
     }
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -70,7 +70,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -81,7 +81,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/ballerina/rainier/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/ballerina/rainier/Ballerina.toml
@@ -7,10 +7,10 @@ distribution = "2201.11.0-20241117-133400-a3054b77"
 [build-options]
 observabilityIncluded = false
 
-[[platform.java21.repository]]
+[[platform.java25.repository]]
 id="wso2-nexus"
 url = "https://maven.wso2.org/nexus/content/groups/public/"
 
-[[platform.java21.repository]]
+[[platform.java25.repository]]
 id="wso2-nexus-snapshot"
 url = "https://maven.wso2.org/nexus/content/repositories/snapshots/"

--- a/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/ballerina/rainier/resources/Ballerina.toml
+++ b/architecture-model-generator/modules/architecture-model-generator-ls-extension/src/test/resources/ballerina/rainier/resources/Ballerina.toml
@@ -14,10 +14,10 @@ user = "root"
 password = "Test123#"
 database = "rainier_db"
 
-[[platform.java21.repository]]
+[[platform.java25.repository]]
 id="wso2-nexus"
 url = "https://maven.wso2.org/nexus/content/groups/public/"
 
-[[platform.java21.repository]]
+[[platform.java25.repository]]
 id="wso2-nexus-snapshot"
 url = "https://maven.wso2.org/nexus/content/repositories/snapshots/"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadMultipleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,13 @@ allprojects {
 
 subprojects {
     apply plugin: "java"
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
     configurations {
         ballerinaStdLibs
     }
@@ -165,12 +172,17 @@ def targetSequenceDiagramGeneratorCore = file("$project.rootDir/sequence-model-g
 def targetSequenceDiagramGeneratorLSExt = file("$project.rootDir/sequence-model-generator/modules/sequence-model-generator-ls-extension/build/libs/sequence-model-generator-ls-extension-${project.version}.jar")
 def targetTestManagerServiceLSExt = file("$project.rootDir/test-manager-service/modules/test-manager-service-ls-extension/build/libs/test-manager-service-ls-extension-${project.version}.jar")
 
+abstract class RootBallerinaExecHelper {
+    @javax.inject.Inject abstract org.gradle.process.ExecOperations getExecOperations()
+}
+
 // TODO: Remove this once the workspace manager is refactored to import modules where necessary.
 def pullBallerinaModule(String packageName, String version = null, String orgName = "ballerinax") {
     tasks.register("pullBallerinaModule_${packageName.replace('/', '_')}") {
         doLast {
+            def execHelper = project.objects.newInstance(RootBallerinaExecHelper)
             def errOutput = new ByteArrayOutputStream()
-            def result = exec {
+            def result = execHelper.execOperations.exec {
                 ignoreExitValue = true
 
                 // Check if the package exists in the ballerina user home
@@ -305,12 +317,12 @@ test.dependsOn rootProject.pullBallerinaModule('kafka', ballerinaxKafkaVersion)
 test.dependsOn rootProject.pullBallerinaModule('rabbitmq', ballerinaxRabbitmqVersion)
 test.dependsOn rootProject.pullBallerinaModule('trigger.github', ballerinaxGithubTriggerVersion)
 
-task build {
+tasks.named('build') {
     dependsOn test
     dependsOn createArtifactZip
 }
 
-task clean {
+tasks.named('clean') {
     delete "build"
     delete "dist"
 }

--- a/flow-model-generator/modules/flow-model-generator-core/build.gradle
+++ b/flow-model-generator/modules/flow-model-generator-core/build.gradle
@@ -66,13 +66,13 @@ dependencies {
     implementation "org.ballerinalang:toml-parser:${ballerinaLangVersion}"
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -85,7 +85,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -96,7 +96,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/flow-model-generator/modules/flow-model-generator-ls-extension/build.gradle
+++ b/flow-model-generator/modules/flow-model-generator-ls-extension/build.gradle
@@ -57,13 +57,13 @@ dependencies {
     implementation "io.ballerina.openapi:core:${openAPICoreVersion}"
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -76,7 +76,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -87,7 +87,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,19 @@
 org.gradle.caching=true
 group=org.ballerinalang
 version=2.6.2-SNAPSHOT
-ballerinaLangVersion=2201.13.0-m2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=4.0.0
 checkStyleToolVersion=10.12.1
 downloadPluginVersion=5.4.0
 eclipseLsp4jVersion=0.24.0
 gsonVersion=2.10.1
 puppycrawlCheckstyleVersion=10.12.1
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 shadowJarPluginVersion=8.1.1
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
+jacocoVersion=0.8.13
 testngVersion=7.7.0
 graphqlJavaVersion=21.5
 sqliteJdbcVersion=3.41.2.2

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -43,7 +43,7 @@ dependencies {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
+// sourceCompatibility removed — Java 25 toolchain is configured in root build.gradle
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
@@ -79,13 +79,13 @@ spotbugsMain {
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
     ignoreFailures = true
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 
@@ -94,7 +94,7 @@ spotbugsTest {
 }
 
 test {
-    systemProperty "ballerina.home", "$buildDir"
+    systemProperty "ballerina.home", layout.buildDirectory.get().asFile
     systemProperty "org.apache.commons.logging.Log", "org.apache.commons.logging.impl.NoOpLog"
     testLogging {
         showStackTraces = true
@@ -104,7 +104,7 @@ test {
     }
     jacoco {
         enabled = true
-        destinationFile = file("$buildDir/coverage-reports/jacoco.exec")
+        destinationFile = layout.buildDirectory.file("coverage-reports/jacoco.exec").get().asFile
         includeNoLocationClasses = true
         excludes = ['jdk.internal.*']
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/graphql-model-generator/modules/graphql-model-generator-core/build.gradle
+++ b/graphql-model-generator/modules/graphql-model-generator-core/build.gradle
@@ -49,13 +49,13 @@ dependencies {
     }
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -68,7 +68,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -79,7 +79,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/graphql-model-generator/modules/graphql-model-generator-ls-extension/build.gradle
+++ b/graphql-model-generator/modules/graphql-model-generator-ls-extension/build.gradle
@@ -52,13 +52,13 @@ dependencies {
     }
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -71,7 +71,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -82,7 +82,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/sequence-model-generator/modules/sequence-model-generator-core/build.gradle
+++ b/sequence-model-generator/modules/sequence-model-generator-core/build.gradle
@@ -38,13 +38,13 @@ dependencies {
     }
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -57,7 +57,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -68,7 +68,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/sequence-model-generator/modules/sequence-model-generator-ls-extension/build.gradle
+++ b/sequence-model-generator/modules/sequence-model-generator-ls-extension/build.gradle
@@ -48,13 +48,13 @@ dependencies {
     }
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -67,7 +67,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -78,7 +78,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/service-model-generator/modules/service-model-generator-ls-extension/build.gradle
+++ b/service-model-generator/modules/service-model-generator-ls-extension/build.gradle
@@ -61,13 +61,13 @@ dependencies {
     implementation "org.xerial:sqlite-jdbc:${sqliteJdbcVersion}"
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -80,7 +80,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -91,7 +91,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,8 +15,15 @@
  *
  */
 
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'ballerina-dev-tools'
@@ -57,9 +64,9 @@ project(':service-model-generator:service-model-generator-ls-extension').project
 project(':service-model-generator:service-model-index-generator').projectDir = file('service-model-generator/modules/service-model-index-generator')
 project(':test-manager-service:test-manager-service-ls-extension').projectDir = file('test-manager-service/modules/test-manager-service-ls-extension')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -47,4 +47,14 @@
             <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
         </Or>
     </Match>
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
 </FindBugsFilter>

--- a/test-manager-service/modules/test-manager-service-ls-extension/build.gradle
+++ b/test-manager-service/modules/test-manager-service-ls-extension/build.gradle
@@ -60,13 +60,13 @@ dependencies {
     implementation "io.swagger.core.v3:swagger-models"
 }
 
-def balDistribution = file("$project.buildDir/extracted-distribution/jballerina-tools-${ballerinaLangVersion}")
+def balDistribution = layout.buildDirectory.dir("extracted-distribution/jballerina-tools-${ballerinaLangVersion}").get().asFile
 task jBallerinaPack() {
     doLast {
         configurations.balTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File(project.buildDir, "extracted-distribution/")
+                into layout.buildDirectory.dir("extracted-distribution/").get().asFile
             }
         }
     }
@@ -79,7 +79,7 @@ task unpackStdLibs() {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
                 from project.zipTree(artifact.getFile())
-                into new File("${project.buildDir}/extracted-stdlibs/" + artifact.name + "-zip")
+                into layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + "-zip").get().asFile
             }
         }
     }
@@ -90,7 +90,7 @@ task copyStdlibs() {
     doLast {
         /* Standard Libraries */
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-            def artifactExtractedPath = "${project.buildDir}/extracted-stdlibs/" + artifact.name + '-zip'
+            def artifactExtractedPath = layout.buildDirectory.dir("extracted-stdlibs/" + artifact.name + '-zip').get().asFile.absolutePath
             project.copy {
                 def ballerinaDist = "build/extracted-distribution/jballerina-tools-${project.ballerinaLangVersion}"
                 into ballerinaDist


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-20260527-050400-74f7e6bf`; update all `[platform.java21]` TOML sections to `[platform.java25]`
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+); add exclusions for `THROWS`, `AT`, and `USELESS_STRING` detectors introduced in SpotBugs 4.9.x
- **JaCoCo 0.8.13**: Upgrade for Java 25 class file instrumentation support
- **CI workflow**: Update to `actions/setup-java@v4` with `java-version: 25` for JDK 25 runner support

## Test plan
- [ ] `./gradlew build` passes green on CI (full build including tests)
- [ ] SpotBugs passes on all modules
- [ ] CI passes on both Ubuntu and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Gradle 9.5.1 and Java 25 migration

This pull request upgrades the repository to Gradle 9.5.1 and adopts a Java 25 toolchain across the project, plus related build-tool and CI updates to ensure compatibility with the newer Gradle and Java runtimes.

Key changes and intent
- Upgrade build system: Gradle wrapper moved from 8.11.1 → 9.5.1 to use the latest Gradle runtime.
- Modernize build paths: replaced legacy project.buildDir / string-based paths with Gradle’s layout.buildDirectory API across module build scripts to align with Gradle 9.x conventions.
- Exec API modernization: replaced direct Project.exec() usage with injected ExecOperations to conform to Gradle’s recommended APIs.
- Tooling/plugin updates:
  - Ballerina Gradle plugin 2.3.0 → 4.0.0 and ballerinaLangVersion updated to 2201.14.0-20260527-050400-74f7e6bf.
  - net.researchgate.release plugin upgraded to 3.1.0.
  - SpotBugs Gradle plugin upgraded to 6.5.1 and JaCoCo to 0.8.13 to support newer Java class file formats.
  - Added SpotBugs exclusions for new detectors introduced in the updated SpotBugs bundle to keep reports stable.
  - Replaced com.gradle.enterprise plugin with com.gradle.develocity and migrated its configuration block accordingly.
- CI and workflow: GitHub Actions workflows switched to actions/setup-java@v4 with java-version: 25; Windows CI Ballerina setup version bumped.
- Gradle task and test adjustments:
  - Root build configuration rewritten to configure existing tasks via tasks.named(...) rather than redefining them.
  - One Test task adjusted to set failOnNoDiscoveredTests = false to accommodate Gradle 9.5.1 test discovery behavior.
- Build reproducibility and outputs: many modules now use layout.buildDirectory for extraction and artifact locations to centralize and standardize build outputs.

Testing notes (author-provided)
- Full ./gradlew build (including tests) expected to pass on CI.
- SpotBugs and JaCoCo updated to handle Java 25 bytecode; exclusions added to maintain clean reports.
- CI validated for Ubuntu and Windows runners with JDK 25.

Overall goal: update the build environment and related tooling for Java 25 and Gradle 9.5.1, modernize build scripts to current Gradle APIs, and update CI to run on the new toolchain while preserving existing build and test behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-dev-tools/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->